### PR TITLE
feat: support compose.y(a)ml

### DIFF
--- a/backend/api/utils/compose.py
+++ b/backend/api/utils/compose.py
@@ -12,6 +12,8 @@ def find_yml_files(path):
     matches = {}
     for root, _, filenames in os.walk(path, followlinks=True):
         for _ in set().union(
+            fnmatch.filter(filenames, "compose.yml"),
+            fnmatch.filter(filenames, "compose.yaml"),
             fnmatch.filter(filenames, "docker-compose.yml"),
             fnmatch.filter(filenames, "docker-compose.yaml"),
         ):


### PR DESCRIPTION
Newer Docker Compose projects use the shorter `compose.yaml` or `compose.yml` filename.

> The default path for a Compose file is compose.yaml (preferred) or compose.yml that is placed in the working directory. Compose also supports docker-compose.yaml and docker-compose.yml for backwards compatibility of earlier versions.
https://docs.docker.com/compose/intro/compose-application-model/#the-compose-file