### PR TITLE
Update workflows to push to GitHub Packages

### DIFF
--- a/.github/workflows/build-devel.yml
+++ b/.github/workflows/build-devel.yml
@@ -39,11 +39,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1 
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }} 
 
       - name: Build and push
         uses: docker/build-push-action@v2
@@ -53,9 +48,7 @@ jobs:
           build-args: |
             VUE_APP_VERSION=devel-${{ steps.current-time.outputs.formattedTime }}
           tags: |
-            selfhostedpro/yacht:devel
-            selfhostedpro/yacht:devel-${{ steps.current-time.outputs.formattedTime }}
-            ghcr.io/selfhostedpro/yacht:devel
-            ghcr.io/selfhostedpro/yacht:devel-${{ steps.current-time.outputs.formattedTime }}
+            ghcr.io/${{ github.repository_owner }}/yacht:devel
+            ghcr.io/${{ github.repository_owner }}/yacht:devel-${{ steps.current-time.outputs.formattedTime }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -39,11 +39,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1 
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }} 
 
       - name: Build and push
         uses: docker/build-push-action@v2
@@ -53,9 +48,7 @@ jobs:
           build-args: |
             VUE_APP_VERSION=nightly-${{ steps.current-time.outputs.formattedTime }}
           tags: |
-            selfhostedpro/yacht:nightly
-            selfhostedpro/yacht:nightly-${{ steps.current-time.outputs.formattedTime }}
-            ghcr.io/selfhostedpro/yacht:nightly
-            ghcr.io/selfhostedpro/yacht:nightly-${{ steps.current-time.outputs.formattedTime }}
+            ghcr.io/${{ github.repository_owner }}/yacht:nightly
+            ghcr.io/${{ github.repository_owner }}/yacht:nightly-${{ steps.current-time.outputs.formattedTime }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/build-wicked-testdeploy.yml
+++ b/.github/workflows/build-wicked-testdeploy.yml
@@ -39,11 +39,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1 
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }} 
 
       - name: Build and push
         uses: docker/build-push-action@v2
@@ -53,9 +48,7 @@ jobs:
           build-args: |
             VUE_APP_VERSION=devel-${{ steps.current-time.outputs.formattedTime }}
           tags: |
-            selfhostedpro/yacht:devel
-            selfhostedpro/yacht:devel-${{ steps.current-time.outputs.formattedTime }}
-            ghcr.io/selfhostedpro/yacht:devel
-            ghcr.io/selfhostedpro/yacht:devel-${{ steps.current-time.outputs.formattedTime }}
+            ghcr.io/${{ github.repository_owner }}/yacht:devel
+            ghcr.io/${{ github.repository_owner }}/yacht:devel-${{ steps.current-time.outputs.formattedTime }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,11 +39,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1 
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }} 
 
       - name: Build and push
         uses: docker/build-push-action@v2
@@ -53,11 +48,8 @@ jobs:
           build-args: |
             VUE_APP_VERSION=v0.0.7-alpha-${{ steps.current-time.outputs.formattedTime }}
           tags: |
-            selfhostedpro/yacht
-            selfhostedpro/yacht:latest-${{ steps.current-time.outputs.formattedTime }}
-            selfhostedpro/yacht:v0.0.7-alpha-${{ steps.current-time.outputs.formattedTime }}
-            ghcr.io/selfhostedpro/yacht
-            ghcr.io/selfhostedpro/yacht:latest-${{ steps.current-time.outputs.formattedTime }}
-            ghcr.io/selfhostedpro/yacht:v0.0.7-alpha-${{ steps.current-time.outputs.formattedTime }}
+            ghcr.io/${{ github.repository_owner }}/yacht
+            ghcr.io/${{ github.repository_owner }}/yacht:latest-${{ steps.current-time.outputs.formattedTime }}
+            ghcr.io/${{ github.repository_owner }}/yacht:v0.0.7-alpha-${{ steps.current-time.outputs.formattedTime }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -38,11 +38,6 @@ jjobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1 
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }} 
 
       - name: Build and push
         uses: docker/build-push-action@v2
@@ -52,9 +47,7 @@ jjobs:
           build-args: |
             VUE_APP_VERSION=devel-${{ steps.current-time.outputs.formattedTime }}
           tags: |
-            selfhostedpro/yacht:devel
-            selfhostedpro/yacht:devel-${{ steps.current-time.outputs.formattedTime }}
-            ghcr.io/selfhostedpro/yacht:devel
-            ghcr.io/selfhostedpro/yacht:devel-${{ steps.current-time.outputs.formattedTime }}
+            ghcr.io/${{ github.repository_owner }}/yacht:devel
+            ghcr.io/${{ github.repository_owner }}/yacht:devel-${{ steps.current-time.outputs.formattedTime }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/ghcr-mirror.yml
+++ b/.github/workflows/ghcr-mirror.yml
@@ -38,7 +38,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ${{ github.event.inputs.dest-registry }}
-          username: selfhostedpro
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
       -
         name: Mirror ${{ github.event.inputs.dockerhub-repo }} to ${{ github.event.inputs.dest-registry }}/${{ github.event.inputs.dest-repo }}

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -42,11 +42,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1 
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }} 
 
       - name: Build and push
         uses: docker/build-push-action@v2
@@ -56,7 +51,6 @@ jobs:
           build-args: |
             VUE_APP_VERSION=${{ github.event.inputs.release }}
           tags: |
-            selfhostedpro/yacht:${{ github.event.inputs.release }}
-            ghcr.io/selfhostedpro/yacht:${{ github.event.inputs.release }}
+            ghcr.io/${{ github.repository_owner }}/yacht:${{ github.event.inputs.release }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
## Summary
- stop pushing images to Docker Hub
- push images to GHCR using repository owner
- update mirror workflow to use dynamic username

## Testing
- `npm install --legacy-peer-deps` *(fails: many warnings but completes)*
- `npm run lint` *(fails: ESLint is not a constructor)*
- `pytest` *(ran with no tests)*

------
https://chatgpt.com/codex/tasks/task_e_68634616ae4883238c3911c5513adc92