### PR TITLE
Update repo links to Yacht-sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,365 +1,365 @@
 # Changelog
 
-## [Unreleased](https://github.com/wickedyoda/Yacht/tree/HEAD)
+## [Unreleased](https://github.com/Yacht-sh/Yacht/tree/HEAD)
 
-[Full Changelog](https://github.com/wickedyoda/Yacht/compare/v0.0.6-alpha-hf1...HEAD)
-
-**Fixed bugs:**
-
-- \[Bug Report\] Logs overlap making them unreadable [\#323](https://github.com/wickedyoda/Yacht/issues/323)
-
-**Closed issues:**
-
-- Template Variables Not Filled on Application Creation [\#310](https://github.com/wickedyoda/Yacht/issues/310)
-- Yacht is changing permissions of compose folder [\#305](https://github.com/wickedyoda/Yacht/issues/305)
-- Blank page when loading certain projects [\#298](https://github.com/wickedyoda/Yacht/issues/298)
-
-## [v0.0.6-alpha-hf1](https://github.com/wickedyoda/Yacht/tree/v0.0.6-alpha-hf1) (2021-02-24)
-
-[Full Changelog](https://github.com/wickedyoda/Yacht/compare/v0.0.6-alpha...v0.0.6-alpha-hf1)
-
-**Closed issues:**
-
-- Mistaken Docker starting command on README.md [\#308](https://github.com/wickedyoda/Yacht/issues/308)
-- Labels Defined in Template not Loading "Label" Value [\#301](https://github.com/wickedyoda/Yacht/issues/301)
-- \[Feature Request\] Deploy multiple containers from a single file [\#260](https://github.com/wickedyoda/Yacht/issues/260)
-- Template Variables reset [\#251](https://github.com/wickedyoda/Yacht/issues/251)
-- How do you edit a container after it's created from a template? [\#225](https://github.com/wickedyoda/Yacht/issues/225)
-- Add a version indicator [\#205](https://github.com/wickedyoda/Yacht/issues/205)
-- Log Scrolling [\#98](https://github.com/wickedyoda/Yacht/issues/98)
-
-**Merged pull requests:**
-
-- Alpha v0.0.6-hf1 [\#316](https://github.com/wickedyoda/Yacht/pull/316) ([SelfhostedPro](https://github.com/wickedyoda))
-- Nightly [\#315](https://github.com/wickedyoda/Yacht/pull/315) ([SelfhostedPro](https://github.com/wickedyoda))
-- doing bytes formatting on the backend [\#314](https://github.com/wickedyoda/Yacht/pull/314) ([SelfhostedPro](https://github.com/wickedyoda))
-- Nightly [\#313](https://github.com/wickedyoda/Yacht/pull/313) ([SelfhostedPro](https://github.com/wickedyoda))
-- changed barchart to use progress bar [\#312](https://github.com/wickedyoda/Yacht/pull/312) ([SelfhostedPro](https://github.com/wickedyoda))
-- Fixed execution command for Docker container [\#309](https://github.com/wickedyoda/Yacht/pull/309) ([t0xic0der](https://github.com/t0xic0der))
-- fixed mysql support [\#307](https://github.com/wickedyoda/Yacht/pull/307) ([SelfhostedPro](https://github.com/wickedyoda))
-- fix permissions replacement on /config/compose; will ony change owner… [\#306](https://github.com/wickedyoda/Yacht/pull/306) ([SelfhostedPro](https://github.com/wickedyoda))
-- remove accidental bundle; add mysql support back in; [\#304](https://github.com/wickedyoda/Yacht/pull/304) ([SelfhostedPro](https://github.com/wickedyoda))
-- working on fixing theme being unset after auth timeout [\#303](https://github.com/wickedyoda/Yacht/pull/303) ([SelfhostedPro](https://github.com/wickedyoda))
-- Fix labels; refine container name detection; support bundle addition [\#302](https://github.com/wickedyoda/Yacht/pull/302) ([SelfhostedPro](https://github.com/wickedyoda))
-- Nightly [\#300](https://github.com/wickedyoda/Yacht/pull/300) ([SelfhostedPro](https://github.com/wickedyoda))
-- Develop [\#292](https://github.com/wickedyoda/Yacht/pull/292) ([SelfhostedPro](https://github.com/wickedyoda))
-- Nightly [\#291](https://github.com/wickedyoda/Yacht/pull/291) ([SelfhostedPro](https://github.com/wickedyoda))
-
-## [v0.0.6-alpha](https://github.com/wickedyoda/Yacht/tree/v0.0.6-alpha) (2021-02-19)
-
-[Full Changelog](https://github.com/wickedyoda/Yacht/compare/v0.0.5-alpha...v0.0.6-alpha)
-
-**Closed issues:**
-
-- BitwardenRS Data directory not populating at setup [\#283](https://github.com/wickedyoda/Yacht/issues/283)
-- No More Stats after reverse proxy [\#231](https://github.com/wickedyoda/Yacht/issues/231)
-- Add image to ghcr.io repository [\#228](https://github.com/wickedyoda/Yacht/issues/228)
-- 500 error when importing Portainer template [\#223](https://github.com/wickedyoda/Yacht/issues/223)
-- Help wanted [\#221](https://github.com/wickedyoda/Yacht/issues/221)
-- Unable to load UI [\#217](https://github.com/wickedyoda/Yacht/issues/217)
-- Internal Server Error when adding Template Env Var [\#194](https://github.com/wickedyoda/Yacht/issues/194)
-- Unprocessable Entity error when changing user email address to a non valid email address [\#193](https://github.com/wickedyoda/Yacht/issues/193)
-- High cpu-usage when accessing trough Safari on MacOS Catalina [\#157](https://github.com/wickedyoda/Yacht/issues/157)
-- Not able to see my Dashboard any more Reaching over 100 Dockers [\#144](https://github.com/wickedyoda/Yacht/issues/144)
-- Docker Compose Support [\#130](https://github.com/wickedyoda/Yacht/issues/130)
-
-**Merged pull requests:**
-
-- updated readme.md [\#290](https://github.com/wickedyoda/Yacht/pull/290) ([SelfhostedPro](https://github.com/wickedyoda))
-- Nightly [\#289](https://github.com/wickedyoda/Yacht/pull/289) ([SelfhostedPro](https://github.com/wickedyoda))
-- typo on websocket auth [\#288](https://github.com/wickedyoda/Yacht/pull/288) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixing auth check on websockets [\#287](https://github.com/wickedyoda/Yacht/pull/287) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixing DISABLE\_AUTH case matching [\#286](https://github.com/wickedyoda/Yacht/pull/286) ([SelfhostedPro](https://github.com/wickedyoda))
-- working on logout after update [\#285](https://github.com/wickedyoda/Yacht/pull/285) ([SelfhostedPro](https://github.com/wickedyoda))
-- added edit dialog, now will edit even if the name is changed [\#284](https://github.com/wickedyoda/Yacht/pull/284) ([SelfhostedPro](https://github.com/wickedyoda))
-- Comments; Tags; Linting; [\#282](https://github.com/wickedyoda/Yacht/pull/282) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixed stepper in deploy form; tailing logs to last 200 logs; fix chan… [\#281](https://github.com/wickedyoda/Yacht/pull/281) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixed udp ports in edit form [\#280](https://github.com/wickedyoda/Yacht/pull/280) ([SelfhostedPro](https://github.com/wickedyoda))
-- set VUE\_APP\_VERSION on the latest tag [\#279](https://github.com/wickedyoda/Yacht/pull/279) ([SelfhostedPro](https://github.com/wickedyoda))
-- scroll with log [\#278](https://github.com/wickedyoda/Yacht/pull/278) ([SelfhostedPro](https://github.com/wickedyoda))
-- allow empty port settings in edit [\#277](https://github.com/wickedyoda/Yacht/pull/277) ([SelfhostedPro](https://github.com/wickedyoda))
-- added port label to edit form [\#276](https://github.com/wickedyoda/Yacht/pull/276) ([SelfhostedPro](https://github.com/wickedyoda))
-- Projects [\#275](https://github.com/wickedyoda/Yacht/pull/275) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixing appbar menu disappearing even if logged in and auth is enabled [\#274](https://github.com/wickedyoda/Yacht/pull/274) ([SelfhostedPro](https://github.com/wickedyoda))
-- Misc Fixes [\#273](https://github.com/wickedyoda/Yacht/pull/273) ([SelfhostedPro](https://github.com/wickedyoda))
-- added build version tags to devel images [\#272](https://github.com/wickedyoda/Yacht/pull/272) ([SelfhostedPro](https://github.com/wickedyoda))
-- check for DOCKER\_HOST for docker-compose commands [\#271](https://github.com/wickedyoda/Yacht/pull/271) ([SelfhostedPro](https://github.com/wickedyoda))
-- changed version format for devel [\#270](https://github.com/wickedyoda/Yacht/pull/270) ([SelfhostedPro](https://github.com/wickedyoda))
-- Projects [\#269](https://github.com/wickedyoda/Yacht/pull/269) ([SelfhostedPro](https://github.com/wickedyoda))
-- setting up cache for builds [\#268](https://github.com/wickedyoda/Yacht/pull/268) ([SelfhostedPro](https://github.com/wickedyoda))
-- change version build-arg [\#267](https://github.com/wickedyoda/Yacht/pull/267) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixed version info [\#266](https://github.com/wickedyoda/Yacht/pull/266) ([SelfhostedPro](https://github.com/wickedyoda))
-- updating action [\#265](https://github.com/wickedyoda/Yacht/pull/265) ([SelfhostedPro](https://github.com/wickedyoda))
-- triggering action [\#264](https://github.com/wickedyoda/Yacht/pull/264) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixing versioning [\#263](https://github.com/wickedyoda/Yacht/pull/263) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixing build var [\#262](https://github.com/wickedyoda/Yacht/pull/262) ([SelfhostedPro](https://github.com/wickedyoda))
-- added VUE\_APP\_VERSION [\#261](https://github.com/wickedyoda/Yacht/pull/261) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixed docker-compose down [\#259](https://github.com/wickedyoda/Yacht/pull/259) ([SelfhostedPro](https://github.com/wickedyoda))
-- Projects [\#258](https://github.com/wickedyoda/Yacht/pull/258) ([SelfhostedPro](https://github.com/wickedyoda))
-- wipe env for docker-compose commands; Add feedback for Project app ac… [\#257](https://github.com/wickedyoda/Yacht/pull/257) ([SelfhostedPro](https://github.com/wickedyoda))
-- remove envs from docker-compose commands [\#256](https://github.com/wickedyoda/Yacht/pull/256) ([SelfhostedPro](https://github.com/wickedyoda))
-- added feedback for project controls [\#255](https://github.com/wickedyoda/Yacht/pull/255) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixed postgresql requirements [\#254](https://github.com/wickedyoda/Yacht/pull/254) ([SelfhostedPro](https://github.com/wickedyoda))
-- removed -f from docker-compose commands; added wheel; added psycopg2 [\#253](https://github.com/wickedyoda/Yacht/pull/253) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixing update functionality [\#250](https://github.com/wickedyoda/Yacht/pull/250) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixed DISABLE\_AUTH still showing settings [\#249](https://github.com/wickedyoda/Yacht/pull/249) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixing vuex store function for project actions; updating buildx actions; [\#248](https://github.com/wickedyoda/Yacht/pull/248) ([SelfhostedPro](https://github.com/wickedyoda))
-- changed sig verification error to 401;changed action url [\#246](https://github.com/wickedyoda/Yacht/pull/246) ([SelfhostedPro](https://github.com/wickedyoda))
-- working on update feature [\#245](https://github.com/wickedyoda/Yacht/pull/245) ([SelfhostedPro](https://github.com/wickedyoda))
-- Changed sidebar titles;  changed User schema to allow for UUID, str, or int to be compatible with previous db models [\#244](https://github.com/wickedyoda/Yacht/pull/244) ([SelfhostedPro](https://github.com/wickedyoda))
-- Alpha 6 \(v0.0.6-alpha\) [\#243](https://github.com/wickedyoda/Yacht/pull/243) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixed buttons by updating vuetify; removed sidebar for new app/templa… [\#242](https://github.com/wickedyoda/Yacht/pull/242) ([SelfhostedPro](https://github.com/wickedyoda))
-- Projects [\#241](https://github.com/wickedyoda/Yacht/pull/241) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixed router push after project deletion on details page [\#235](https://github.com/wickedyoda/Yacht/pull/235) ([SelfhostedPro](https://github.com/wickedyoda))
-- use a background task for updating yacht;  fixed router push after project deletion on details page  [\#234](https://github.com/wickedyoda/Yacht/pull/234) ([SelfhostedPro](https://github.com/wickedyoda))
-- Error catching for permissions error on mkdir; added delete dialog to projects [\#233](https://github.com/wickedyoda/Yacht/pull/233) ([SelfhostedPro](https://github.com/wickedyoda))
-- added delete functionality inside details; visual changes [\#232](https://github.com/wickedyoda/Yacht/pull/232) ([SelfhostedPro](https://github.com/wickedyoda))
-- Auth rewrite [\#215](https://github.com/wickedyoda/Yacht/pull/215) ([SelfhostedPro](https://github.com/wickedyoda))
-- Deploy form fixes [\#214](https://github.com/wickedyoda/Yacht/pull/214) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixed networking in deploy form [\#213](https://github.com/wickedyoda/Yacht/pull/213) ([SelfhostedPro](https://github.com/wickedyoda))
-- Develop [\#212](https://github.com/wickedyoda/Yacht/pull/212) ([SelfhostedPro](https://github.com/wickedyoda))
-- Themeenv [\#211](https://github.com/wickedyoda/Yacht/pull/211) ([SelfhostedPro](https://github.com/wickedyoda))
-- Merge fixes from develop [\#210](https://github.com/wickedyoda/Yacht/pull/210) ([SelfhostedPro](https://github.com/wickedyoda))
-- Fixes [\#209](https://github.com/wickedyoda/Yacht/pull/209) ([SelfhostedPro](https://github.com/wickedyoda))
-- Sync [\#208](https://github.com/wickedyoda/Yacht/pull/208) ([SelfhostedPro](https://github.com/wickedyoda))
-- Theming; fixes [\#207](https://github.com/wickedyoda/Yacht/pull/207) ([SelfhostedPro](https://github.com/wickedyoda))
-
-## [v0.0.5-alpha](https://github.com/wickedyoda/Yacht/tree/v0.0.5-alpha) (2020-10-31)
-
-[Full Changelog](https://github.com/wickedyoda/Yacht/compare/v0.0.4-hf1...v0.0.5-alpha)
-
-**Merged pull requests:**
-
-- Alpha 5 \(v0.0.5-alpha\) [\#204](https://github.com/wickedyoda/Yacht/pull/204) ([SelfhostedPro](https://github.com/wickedyoda))
-- Docker compose api [\#203](https://github.com/wickedyoda/Yacht/pull/203) ([SelfhostedPro](https://github.com/wickedyoda))
-- changed email field to require valid email before submit [\#198](https://github.com/wickedyoda/Yacht/pull/198) ([SelfhostedPro](https://github.com/wickedyoda))
-- changed how updates are checked for items with multiple RepoDigests [\#196](https://github.com/wickedyoda/Yacht/pull/196) ([SelfhostedPro](https://github.com/wickedyoda))
-- Variables [\#195](https://github.com/wickedyoda/Yacht/pull/195) ([SelfhostedPro](https://github.com/wickedyoda))
-
-## [v0.0.4-hf1](https://github.com/wickedyoda/Yacht/tree/v0.0.4-hf1) (2020-10-22)
-
-[Full Changelog](https://github.com/wickedyoda/Yacht/compare/v0.0.4-alpha...v0.0.4-hf1)
-
-**Implemented enhancements:**
-
-- add an option to put apps into a second net other than bridge by default.  [\#159](https://github.com/wickedyoda/Yacht/issues/159)
-- \[Feature Request\]Support network\_mode [\#155](https://github.com/wickedyoda/Yacht/issues/155)
-- \[Feature Request\] Disable Authentication/Login [\#121](https://github.com/wickedyoda/Yacht/issues/121)
-
-**Closed issues:**
-
-- When pulling an image - screen doesnt refresh [\#182](https://github.com/wickedyoda/Yacht/issues/182)
-- \[Bug Report\] Empty field `ports` of first app in template will trigger an `Internal Server Error` [\#173](https://github.com/wickedyoda/Yacht/issues/173)
-- Make notes more prominent in the deployment process [\#148](https://github.com/wickedyoda/Yacht/issues/148)
-
-**Merged pull requests:**
-
-- fixed stats by adding time back to them for individual apps [\#191](https://github.com/wickedyoda/Yacht/pull/191) ([SelfhostedPro](https://github.com/wickedyoda))
-- added none restart policy [\#190](https://github.com/wickedyoda/Yacht/pull/190) ([SelfhostedPro](https://github.com/wickedyoda))
-- Theming [\#189](https://github.com/wickedyoda/Yacht/pull/189) ([SelfhostedPro](https://github.com/wickedyoda))
-- modified chart sizes [\#188](https://github.com/wickedyoda/Yacht/pull/188) ([SelfhostedPro](https://github.com/wickedyoda))
-- Theming [\#187](https://github.com/wickedyoda/Yacht/pull/187) ([SelfhostedPro](https://github.com/wickedyoda))
-- Theming [\#186](https://github.com/wickedyoda/Yacht/pull/186) ([SelfhostedPro](https://github.com/wickedyoda))
-- Theming [\#185](https://github.com/wickedyoda/Yacht/pull/185) ([SelfhostedPro](https://github.com/wickedyoda))
-- added digitalocean build [\#184](https://github.com/wickedyoda/Yacht/pull/184) ([SelfhostedPro](https://github.com/wickedyoda))
-- Theming [\#183](https://github.com/wickedyoda/Yacht/pull/183) ([SelfhostedPro](https://github.com/wickedyoda))
-- \[Snyk\] Security upgrade chart.js from 2.9.3 to 2.9.4 [\#181](https://github.com/wickedyoda/Yacht/pull/181) ([snyk-bot](https://github.com/snyk-bot))
-- Alpha 4 Hotfix 1 \(v0.0.4-hf1\) [\#180](https://github.com/wickedyoda/Yacht/pull/180) ([SelfhostedPro](https://github.com/wickedyoda))
-- Theming [\#179](https://github.com/wickedyoda/Yacht/pull/179) ([SelfhostedPro](https://github.com/wickedyoda))
-- added rstrip to refresh\_template [\#178](https://github.com/wickedyoda/Yacht/pull/178) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixing error handling on template variables [\#177](https://github.com/wickedyoda/Yacht/pull/177) ([SelfhostedPro](https://github.com/wickedyoda))
-- changed conv\_ports2dict to check for the length before checking the d… [\#176](https://github.com/wickedyoda/Yacht/pull/176) ([SelfhostedPro](https://github.com/wickedyoda))
-- troubleshooting templates and template variables [\#175](https://github.com/wickedyoda/Yacht/pull/175) ([SelfhostedPro](https://github.com/wickedyoda))
-- Error handling [\#174](https://github.com/wickedyoda/Yacht/pull/174) ([SelfhostedPro](https://github.com/wickedyoda))
-
-## [v0.0.4-alpha](https://github.com/wickedyoda/Yacht/tree/v0.0.4-alpha) (2020-10-17)
-
-[Full Changelog](https://github.com/wickedyoda/Yacht/compare/v0.0.3-alpha-hf1...v0.0.4-alpha)
-
-**Implemented enhancements:**
-
-- \[Feature Request\] Customizable column views in "View Applications"-page [\#102](https://github.com/wickedyoda/Yacht/issues/102)
-
-**Closed issues:**
-
--  Internal Server Error: error while creating mount source path '/yacht/AppData/Config/Heimdall': mkdir /yacht: read-only file system  [\#160](https://github.com/wickedyoda/Yacht/issues/160)
-- Issue with Yacht dashboard - Exceeding the max Dokcer count - I think. [\#145](https://github.com/wickedyoda/Yacht/issues/145)
-- Can't View dashboard anymore [\#137](https://github.com/wickedyoda/Yacht/issues/137)
-- \[Feature Request\] Show Stack/Compose a container belongs to in "View Application"-page [\#101](https://github.com/wickedyoda/Yacht/issues/101)
-- Websockets not working behind reverse proxy [\#72](https://github.com/wickedyoda/Yacht/issues/72)
-
-**Merged pull requests:**
-
-- added proxy read timeout [\#172](https://github.com/wickedyoda/Yacht/pull/172) ([SelfhostedPro](https://github.com/wickedyoda))
-- added network\_mode to templates and db [\#171](https://github.com/wickedyoda/Yacht/pull/171) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixed app update issue; fixed 422 error on page load \(checks for auth… [\#170](https://github.com/wickedyoda/Yacht/pull/170) ([SelfhostedPro](https://github.com/wickedyoda))
-- added error check to the check\_updates function if it's not able to g… [\#169](https://github.com/wickedyoda/Yacht/pull/169) ([SelfhostedPro](https://github.com/wickedyoda))
-- removed volumes from deploy form to prevent confusion [\#168](https://github.com/wickedyoda/Yacht/pull/168) ([SelfhostedPro](https://github.com/wickedyoda))
-- added error handling to image methods [\#167](https://github.com/wickedyoda/Yacht/pull/167) ([SelfhostedPro](https://github.com/wickedyoda))
-- added network and network\_mode to the deploy form; added a drop down … [\#166](https://github.com/wickedyoda/Yacht/pull/166) ([SelfhostedPro](https://github.com/wickedyoda))
-- removed required indicator from ipv4 fields [\#165](https://github.com/wickedyoda/Yacht/pull/165) ([SelfhostedPro](https://github.com/wickedyoda))
-- added better network error handling; formatted all the python stuff w... [\#164](https://github.com/wickedyoda/Yacht/pull/164) ([SelfhostedPro](https://github.com/wickedyoda))
-- Added network creation form [\#163](https://github.com/wickedyoda/Yacht/pull/163) ([SelfhostedPro](https://github.com/wickedyoda))
-- added basic network managment \(other than creating\) [\#162](https://github.com/wickedyoda/Yacht/pull/162) ([SelfhostedPro](https://github.com/wickedyoda))
-- Added image and volume management [\#161](https://github.com/wickedyoda/Yacht/pull/161) ([SelfhostedPro](https://github.com/wickedyoda))
-- modified images to not show test builds; fixed issue with image detai… [\#158](https://github.com/wickedyoda/Yacht/pull/158) ([SelfhostedPro](https://github.com/wickedyoda))
-- Disable Auth Variable [\#154](https://github.com/wickedyoda/Yacht/pull/154) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixed updating template list on delete [\#153](https://github.com/wickedyoda/Yacht/pull/153) ([SelfhostedPro](https://github.com/wickedyoda))
-- Image Managment [\#152](https://github.com/wickedyoda/Yacht/pull/152) ([SelfhostedPro](https://github.com/wickedyoda))
-- \[Snyk\] Security upgrade passlib from 1.7.2 to 1.7.3 [\#150](https://github.com/wickedyoda/Yacht/pull/150) ([snyk-bot](https://github.com/snyk-bot))
-- added notes to deploy form [\#149](https://github.com/wickedyoda/Yacht/pull/149) ([SelfhostedPro](https://github.com/wickedyoda))
-- Alpha 4 \(v0.0.4-alpha\) [\#147](https://github.com/wickedyoda/Yacht/pull/147) ([SelfhostedPro](https://github.com/wickedyoda))
-- added filterable columns [\#146](https://github.com/wickedyoda/Yacht/pull/146) ([SelfhostedPro](https://github.com/wickedyoda))
-
-## [v0.0.3-alpha-hf1](https://github.com/wickedyoda/Yacht/tree/v0.0.3-alpha-hf1) (2020-10-03)
-
-[Full Changelog](https://github.com/wickedyoda/Yacht/compare/v0.0.3-alpha...v0.0.3-alpha-hf1)
-
-**Closed issues:**
-
-- \[Feature Request\] Add Container Controllbuttons inside the App Page [\#135](https://github.com/wickedyoda/Yacht/issues/135)
-
-**Merged pull requests:**
-
-- Hotfix [\#143](https://github.com/wickedyoda/Yacht/pull/143) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixed update functionality for if image is missing [\#142](https://github.com/wickedyoda/Yacht/pull/142) ([SelfhostedPro](https://github.com/wickedyoda))
-
-## [v0.0.3-alpha](https://github.com/wickedyoda/Yacht/tree/v0.0.3-alpha) (2020-10-03)
-
-[Full Changelog](https://github.com/wickedyoda/Yacht/compare/v0.0.1-alpha...v0.0.3-alpha)
-
-**Implemented enhancements:**
-
-- \[Feature Request\] Add container label support [\#106](https://github.com/wickedyoda/Yacht/issues/106)
+[Full Changelog](https://github.com/Yacht-sh/Yacht/compare/v0.0.6-alpha-hf1...HEAD)
 
 **Fixed bugs:**
 
-- docker stats reported as null for ARM [\#115](https://github.com/wickedyoda/Yacht/issues/115)
+- \[Bug Report\] Logs overlap making them unreadable [\#323](https://github.com/Yacht-sh/Yacht/issues/323)
 
 **Closed issues:**
 
-- \[Feature Request\] Ability to pull & deploy new \(latest\) image of a already deployed container [\#131](https://github.com/wickedyoda/Yacht/issues/131)
-- Add devices section to templates [\#88](https://github.com/wickedyoda/Yacht/issues/88)
+- Template Variables Not Filled on Application Creation [\#310](https://github.com/Yacht-sh/Yacht/issues/310)
+- Yacht is changing permissions of compose folder [\#305](https://github.com/Yacht-sh/Yacht/issues/305)
+- Blank page when loading certain projects [\#298](https://github.com/Yacht-sh/Yacht/issues/298)
+
+## [v0.0.6-alpha-hf1](https://github.com/Yacht-sh/Yacht/tree/v0.0.6-alpha-hf1) (2021-02-24)
+
+[Full Changelog](https://github.com/Yacht-sh/Yacht/compare/v0.0.6-alpha...v0.0.6-alpha-hf1)
+
+**Closed issues:**
+
+- Mistaken Docker starting command on README.md [\#308](https://github.com/Yacht-sh/Yacht/issues/308)
+- Labels Defined in Template not Loading "Label" Value [\#301](https://github.com/Yacht-sh/Yacht/issues/301)
+- \[Feature Request\] Deploy multiple containers from a single file [\#260](https://github.com/Yacht-sh/Yacht/issues/260)
+- Template Variables reset [\#251](https://github.com/Yacht-sh/Yacht/issues/251)
+- How do you edit a container after it's created from a template? [\#225](https://github.com/Yacht-sh/Yacht/issues/225)
+- Add a version indicator [\#205](https://github.com/Yacht-sh/Yacht/issues/205)
+- Log Scrolling [\#98](https://github.com/Yacht-sh/Yacht/issues/98)
 
 **Merged pull requests:**
 
-- Alpha 3 \(v0.0.3-alpha\) Update [\#141](https://github.com/wickedyoda/Yacht/pull/141) ([SelfhostedPro](https://github.com/wickedyoda))
-- added check to see if templates list is empty and prompt to add a tem… [\#140](https://github.com/wickedyoda/Yacht/pull/140) ([SelfhostedPro](https://github.com/wickedyoda))
-- Updating [\#139](https://github.com/wickedyoda/Yacht/pull/139) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixed issue where Yacht wouldn't show it's updatable even if there's … [\#138](https://github.com/wickedyoda/Yacht/pull/138) ([SelfhostedPro](https://github.com/wickedyoda))
-- added app actions to app details page [\#136](https://github.com/wickedyoda/Yacht/pull/136) ([SelfhostedPro](https://github.com/wickedyoda))
-- added update checks [\#134](https://github.com/wickedyoda/Yacht/pull/134) ([SelfhostedPro](https://github.com/wickedyoda))
-- working on ability to check for updates [\#133](https://github.com/wickedyoda/Yacht/pull/133) ([SelfhostedPro](https://github.com/wickedyoda))
-- Error Handling [\#132](https://github.com/wickedyoda/Yacht/pull/132) ([SelfhostedPro](https://github.com/wickedyoda))
-- Updating [\#129](https://github.com/wickedyoda/Yacht/pull/129) ([SelfhostedPro](https://github.com/wickedyoda))
-- changed to using watchtower from custom solution [\#128](https://github.com/wickedyoda/Yacht/pull/128) ([SelfhostedPro](https://github.com/wickedyoda))
-- fixed update ports [\#127](https://github.com/wickedyoda/Yacht/pull/127) ([SelfhostedPro](https://github.com/wickedyoda))
-- added self update ability [\#126](https://github.com/wickedyoda/Yacht/pull/126) ([SelfhostedPro](https://github.com/wickedyoda))
-- disable updating yacht from yacht [\#125](https://github.com/wickedyoda/Yacht/pull/125) ([SelfhostedPro](https://github.com/wickedyoda))
-- Updating [\#124](https://github.com/wickedyoda/Yacht/pull/124) ([SelfhostedPro](https://github.com/wickedyoda))
-- removed purge from serverinfo [\#123](https://github.com/wickedyoda/Yacht/pull/123) ([SelfhostedPro](https://github.com/wickedyoda))
-- added separate buttons for purging and added snack for number of item… [\#122](https://github.com/wickedyoda/Yacht/pull/122) ([SelfhostedPro](https://github.com/wickedyoda))
+- Alpha v0.0.6-hf1 [\#316](https://github.com/Yacht-sh/Yacht/pull/316) ([SelfhostedPro](https://github.com/wickedyoda))
+- Nightly [\#315](https://github.com/Yacht-sh/Yacht/pull/315) ([SelfhostedPro](https://github.com/wickedyoda))
+- doing bytes formatting on the backend [\#314](https://github.com/Yacht-sh/Yacht/pull/314) ([SelfhostedPro](https://github.com/wickedyoda))
+- Nightly [\#313](https://github.com/Yacht-sh/Yacht/pull/313) ([SelfhostedPro](https://github.com/wickedyoda))
+- changed barchart to use progress bar [\#312](https://github.com/Yacht-sh/Yacht/pull/312) ([SelfhostedPro](https://github.com/wickedyoda))
+- Fixed execution command for Docker container [\#309](https://github.com/Yacht-sh/Yacht/pull/309) ([t0xic0der](https://github.com/t0xic0der))
+- fixed mysql support [\#307](https://github.com/Yacht-sh/Yacht/pull/307) ([SelfhostedPro](https://github.com/wickedyoda))
+- fix permissions replacement on /config/compose; will ony change owner… [\#306](https://github.com/Yacht-sh/Yacht/pull/306) ([SelfhostedPro](https://github.com/wickedyoda))
+- remove accidental bundle; add mysql support back in; [\#304](https://github.com/Yacht-sh/Yacht/pull/304) ([SelfhostedPro](https://github.com/wickedyoda))
+- working on fixing theme being unset after auth timeout [\#303](https://github.com/Yacht-sh/Yacht/pull/303) ([SelfhostedPro](https://github.com/wickedyoda))
+- Fix labels; refine container name detection; support bundle addition [\#302](https://github.com/Yacht-sh/Yacht/pull/302) ([SelfhostedPro](https://github.com/wickedyoda))
+- Nightly [\#300](https://github.com/Yacht-sh/Yacht/pull/300) ([SelfhostedPro](https://github.com/wickedyoda))
+- Develop [\#292](https://github.com/Yacht-sh/Yacht/pull/292) ([SelfhostedPro](https://github.com/wickedyoda))
+- Nightly [\#291](https://github.com/Yacht-sh/Yacht/pull/291) ([SelfhostedPro](https://github.com/wickedyoda))
 
-## [v0.0.1-alpha](https://github.com/wickedyoda/Yacht/tree/v0.0.1-alpha) (2020-09-26)
+## [v0.0.6-alpha](https://github.com/Yacht-sh/Yacht/tree/v0.0.6-alpha) (2021-02-19)
 
-[Full Changelog](https://github.com/wickedyoda/Yacht/compare/v0.0.2-alpha...v0.0.1-alpha)
+[Full Changelog](https://github.com/Yacht-sh/Yacht/compare/v0.0.5-alpha...v0.0.6-alpha)
 
-## [v0.0.2-alpha](https://github.com/wickedyoda/Yacht/tree/v0.0.2-alpha) (2020-09-26)
+**Closed issues:**
 
-[Full Changelog](https://github.com/wickedyoda/Yacht/compare/v0.01-alpha...v0.0.2-alpha)
+- BitwardenRS Data directory not populating at setup [\#283](https://github.com/Yacht-sh/Yacht/issues/283)
+- No More Stats after reverse proxy [\#231](https://github.com/Yacht-sh/Yacht/issues/231)
+- Add image to ghcr.io repository [\#228](https://github.com/Yacht-sh/Yacht/issues/228)
+- 500 error when importing Portainer template [\#223](https://github.com/Yacht-sh/Yacht/issues/223)
+- Help wanted [\#221](https://github.com/Yacht-sh/Yacht/issues/221)
+- Unable to load UI [\#217](https://github.com/Yacht-sh/Yacht/issues/217)
+- Internal Server Error when adding Template Env Var [\#194](https://github.com/Yacht-sh/Yacht/issues/194)
+- Unprocessable Entity error when changing user email address to a non valid email address [\#193](https://github.com/Yacht-sh/Yacht/issues/193)
+- High cpu-usage when accessing trough Safari on MacOS Catalina [\#157](https://github.com/Yacht-sh/Yacht/issues/157)
+- Not able to see my Dashboard any more Reaching over 100 Dockers [\#144](https://github.com/Yacht-sh/Yacht/issues/144)
+- Docker Compose Support [\#130](https://github.com/Yacht-sh/Yacht/issues/130)
+
+**Merged pull requests:**
+
+- updated readme.md [\#290](https://github.com/Yacht-sh/Yacht/pull/290) ([SelfhostedPro](https://github.com/wickedyoda))
+- Nightly [\#289](https://github.com/Yacht-sh/Yacht/pull/289) ([SelfhostedPro](https://github.com/wickedyoda))
+- typo on websocket auth [\#288](https://github.com/Yacht-sh/Yacht/pull/288) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixing auth check on websockets [\#287](https://github.com/Yacht-sh/Yacht/pull/287) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixing DISABLE\_AUTH case matching [\#286](https://github.com/Yacht-sh/Yacht/pull/286) ([SelfhostedPro](https://github.com/wickedyoda))
+- working on logout after update [\#285](https://github.com/Yacht-sh/Yacht/pull/285) ([SelfhostedPro](https://github.com/wickedyoda))
+- added edit dialog, now will edit even if the name is changed [\#284](https://github.com/Yacht-sh/Yacht/pull/284) ([SelfhostedPro](https://github.com/wickedyoda))
+- Comments; Tags; Linting; [\#282](https://github.com/Yacht-sh/Yacht/pull/282) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixed stepper in deploy form; tailing logs to last 200 logs; fix chan… [\#281](https://github.com/Yacht-sh/Yacht/pull/281) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixed udp ports in edit form [\#280](https://github.com/Yacht-sh/Yacht/pull/280) ([SelfhostedPro](https://github.com/wickedyoda))
+- set VUE\_APP\_VERSION on the latest tag [\#279](https://github.com/Yacht-sh/Yacht/pull/279) ([SelfhostedPro](https://github.com/wickedyoda))
+- scroll with log [\#278](https://github.com/Yacht-sh/Yacht/pull/278) ([SelfhostedPro](https://github.com/wickedyoda))
+- allow empty port settings in edit [\#277](https://github.com/Yacht-sh/Yacht/pull/277) ([SelfhostedPro](https://github.com/wickedyoda))
+- added port label to edit form [\#276](https://github.com/Yacht-sh/Yacht/pull/276) ([SelfhostedPro](https://github.com/wickedyoda))
+- Projects [\#275](https://github.com/Yacht-sh/Yacht/pull/275) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixing appbar menu disappearing even if logged in and auth is enabled [\#274](https://github.com/Yacht-sh/Yacht/pull/274) ([SelfhostedPro](https://github.com/wickedyoda))
+- Misc Fixes [\#273](https://github.com/Yacht-sh/Yacht/pull/273) ([SelfhostedPro](https://github.com/wickedyoda))
+- added build version tags to devel images [\#272](https://github.com/Yacht-sh/Yacht/pull/272) ([SelfhostedPro](https://github.com/wickedyoda))
+- check for DOCKER\_HOST for docker-compose commands [\#271](https://github.com/Yacht-sh/Yacht/pull/271) ([SelfhostedPro](https://github.com/wickedyoda))
+- changed version format for devel [\#270](https://github.com/Yacht-sh/Yacht/pull/270) ([SelfhostedPro](https://github.com/wickedyoda))
+- Projects [\#269](https://github.com/Yacht-sh/Yacht/pull/269) ([SelfhostedPro](https://github.com/wickedyoda))
+- setting up cache for builds [\#268](https://github.com/Yacht-sh/Yacht/pull/268) ([SelfhostedPro](https://github.com/wickedyoda))
+- change version build-arg [\#267](https://github.com/Yacht-sh/Yacht/pull/267) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixed version info [\#266](https://github.com/Yacht-sh/Yacht/pull/266) ([SelfhostedPro](https://github.com/wickedyoda))
+- updating action [\#265](https://github.com/Yacht-sh/Yacht/pull/265) ([SelfhostedPro](https://github.com/wickedyoda))
+- triggering action [\#264](https://github.com/Yacht-sh/Yacht/pull/264) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixing versioning [\#263](https://github.com/Yacht-sh/Yacht/pull/263) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixing build var [\#262](https://github.com/Yacht-sh/Yacht/pull/262) ([SelfhostedPro](https://github.com/wickedyoda))
+- added VUE\_APP\_VERSION [\#261](https://github.com/Yacht-sh/Yacht/pull/261) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixed docker-compose down [\#259](https://github.com/Yacht-sh/Yacht/pull/259) ([SelfhostedPro](https://github.com/wickedyoda))
+- Projects [\#258](https://github.com/Yacht-sh/Yacht/pull/258) ([SelfhostedPro](https://github.com/wickedyoda))
+- wipe env for docker-compose commands; Add feedback for Project app ac… [\#257](https://github.com/Yacht-sh/Yacht/pull/257) ([SelfhostedPro](https://github.com/wickedyoda))
+- remove envs from docker-compose commands [\#256](https://github.com/Yacht-sh/Yacht/pull/256) ([SelfhostedPro](https://github.com/wickedyoda))
+- added feedback for project controls [\#255](https://github.com/Yacht-sh/Yacht/pull/255) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixed postgresql requirements [\#254](https://github.com/Yacht-sh/Yacht/pull/254) ([SelfhostedPro](https://github.com/wickedyoda))
+- removed -f from docker-compose commands; added wheel; added psycopg2 [\#253](https://github.com/Yacht-sh/Yacht/pull/253) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixing update functionality [\#250](https://github.com/Yacht-sh/Yacht/pull/250) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixed DISABLE\_AUTH still showing settings [\#249](https://github.com/Yacht-sh/Yacht/pull/249) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixing vuex store function for project actions; updating buildx actions; [\#248](https://github.com/Yacht-sh/Yacht/pull/248) ([SelfhostedPro](https://github.com/wickedyoda))
+- changed sig verification error to 401;changed action url [\#246](https://github.com/Yacht-sh/Yacht/pull/246) ([SelfhostedPro](https://github.com/wickedyoda))
+- working on update feature [\#245](https://github.com/Yacht-sh/Yacht/pull/245) ([SelfhostedPro](https://github.com/wickedyoda))
+- Changed sidebar titles;  changed User schema to allow for UUID, str, or int to be compatible with previous db models [\#244](https://github.com/Yacht-sh/Yacht/pull/244) ([SelfhostedPro](https://github.com/wickedyoda))
+- Alpha 6 \(v0.0.6-alpha\) [\#243](https://github.com/Yacht-sh/Yacht/pull/243) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixed buttons by updating vuetify; removed sidebar for new app/templa… [\#242](https://github.com/Yacht-sh/Yacht/pull/242) ([SelfhostedPro](https://github.com/wickedyoda))
+- Projects [\#241](https://github.com/Yacht-sh/Yacht/pull/241) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixed router push after project deletion on details page [\#235](https://github.com/Yacht-sh/Yacht/pull/235) ([SelfhostedPro](https://github.com/wickedyoda))
+- use a background task for updating yacht;  fixed router push after project deletion on details page  [\#234](https://github.com/Yacht-sh/Yacht/pull/234) ([SelfhostedPro](https://github.com/wickedyoda))
+- Error catching for permissions error on mkdir; added delete dialog to projects [\#233](https://github.com/Yacht-sh/Yacht/pull/233) ([SelfhostedPro](https://github.com/wickedyoda))
+- added delete functionality inside details; visual changes [\#232](https://github.com/Yacht-sh/Yacht/pull/232) ([SelfhostedPro](https://github.com/wickedyoda))
+- Auth rewrite [\#215](https://github.com/Yacht-sh/Yacht/pull/215) ([SelfhostedPro](https://github.com/wickedyoda))
+- Deploy form fixes [\#214](https://github.com/Yacht-sh/Yacht/pull/214) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixed networking in deploy form [\#213](https://github.com/Yacht-sh/Yacht/pull/213) ([SelfhostedPro](https://github.com/wickedyoda))
+- Develop [\#212](https://github.com/Yacht-sh/Yacht/pull/212) ([SelfhostedPro](https://github.com/wickedyoda))
+- Themeenv [\#211](https://github.com/Yacht-sh/Yacht/pull/211) ([SelfhostedPro](https://github.com/wickedyoda))
+- Merge fixes from develop [\#210](https://github.com/Yacht-sh/Yacht/pull/210) ([SelfhostedPro](https://github.com/wickedyoda))
+- Fixes [\#209](https://github.com/Yacht-sh/Yacht/pull/209) ([SelfhostedPro](https://github.com/wickedyoda))
+- Sync [\#208](https://github.com/Yacht-sh/Yacht/pull/208) ([SelfhostedPro](https://github.com/wickedyoda))
+- Theming; fixes [\#207](https://github.com/Yacht-sh/Yacht/pull/207) ([SelfhostedPro](https://github.com/wickedyoda))
+
+## [v0.0.5-alpha](https://github.com/Yacht-sh/Yacht/tree/v0.0.5-alpha) (2020-10-31)
+
+[Full Changelog](https://github.com/Yacht-sh/Yacht/compare/v0.0.4-hf1...v0.0.5-alpha)
+
+**Merged pull requests:**
+
+- Alpha 5 \(v0.0.5-alpha\) [\#204](https://github.com/Yacht-sh/Yacht/pull/204) ([SelfhostedPro](https://github.com/wickedyoda))
+- Docker compose api [\#203](https://github.com/Yacht-sh/Yacht/pull/203) ([SelfhostedPro](https://github.com/wickedyoda))
+- changed email field to require valid email before submit [\#198](https://github.com/Yacht-sh/Yacht/pull/198) ([SelfhostedPro](https://github.com/wickedyoda))
+- changed how updates are checked for items with multiple RepoDigests [\#196](https://github.com/Yacht-sh/Yacht/pull/196) ([SelfhostedPro](https://github.com/wickedyoda))
+- Variables [\#195](https://github.com/Yacht-sh/Yacht/pull/195) ([SelfhostedPro](https://github.com/wickedyoda))
+
+## [v0.0.4-hf1](https://github.com/Yacht-sh/Yacht/tree/v0.0.4-hf1) (2020-10-22)
+
+[Full Changelog](https://github.com/Yacht-sh/Yacht/compare/v0.0.4-alpha...v0.0.4-hf1)
 
 **Implemented enhancements:**
 
-- \[Feature Request\] Expand View Applications page [\#77](https://github.com/wickedyoda/Yacht/issues/77)
+- add an option to put apps into a second net other than bridge by default.  [\#159](https://github.com/Yacht-sh/Yacht/issues/159)
+- \[Feature Request\]Support network\_mode [\#155](https://github.com/Yacht-sh/Yacht/issues/155)
+- \[Feature Request\] Disable Authentication/Login [\#121](https://github.com/Yacht-sh/Yacht/issues/121)
 
 **Closed issues:**
 
-- \[Feature Request\] Container start line storage [\#112](https://github.com/wickedyoda/Yacht/issues/112)
-- Support for Docker Socket Proxy [\#107](https://github.com/wickedyoda/Yacht/issues/107)
-- Crash on start [\#104](https://github.com/wickedyoda/Yacht/issues/104)
-- \[Feature Request\] Ports in "View Application"-page [\#100](https://github.com/wickedyoda/Yacht/issues/100)
-- Max CPU showing above 100% [\#97](https://github.com/wickedyoda/Yacht/issues/97)
-- \[Feature Request\] Move the port link to the apps page [\#87](https://github.com/wickedyoda/Yacht/issues/87)
-- \[Feature Request\] Port Descriptions [\#73](https://github.com/wickedyoda/Yacht/issues/73)
+- When pulling an image - screen doesnt refresh [\#182](https://github.com/Yacht-sh/Yacht/issues/182)
+- \[Bug Report\] Empty field `ports` of first app in template will trigger an `Internal Server Error` [\#173](https://github.com/Yacht-sh/Yacht/issues/173)
+- Make notes more prominent in the deployment process [\#148](https://github.com/Yacht-sh/Yacht/issues/148)
 
 **Merged pull requests:**
 
-- change mem variables to None if they aren't reported by docker [\#120](https://github.com/wickedyoda/Yacht/pull/120) ([SelfhostedPro](https://github.com/wickedyoda))
-- added github link and troubleshooting problem [\#119](https://github.com/wickedyoda/Yacht/pull/119) ([SelfhostedPro](https://github.com/wickedyoda))
-- Port labels [\#118](https://github.com/wickedyoda/Yacht/pull/118) ([SelfhostedPro](https://github.com/wickedyoda))
-- linted and auto-fixed [\#117](https://github.com/wickedyoda/Yacht/pull/117) ([SelfhostedPro](https://github.com/wickedyoda))
-- improved error reporting on container deployment and fixed labels [\#116](https://github.com/wickedyoda/Yacht/pull/116) ([SelfhostedPro](https://github.com/wickedyoda))
-- added check for alembiic versions folder [\#114](https://github.com/wickedyoda/Yacht/pull/114) ([SelfhostedPro](https://github.com/wickedyoda))
-- Port labels [\#111](https://github.com/wickedyoda/Yacht/pull/111) ([SelfhostedPro](https://github.com/wickedyoda))
-- Merge Develop [\#110](https://github.com/wickedyoda/Yacht/pull/110) ([SelfhostedPro](https://github.com/wickedyoda))
-- Port labels [\#109](https://github.com/wickedyoda/Yacht/pull/109) ([SelfhostedPro](https://github.com/wickedyoda))
-- Fix nginx config not copying correctly on NAS OSs [\#105](https://github.com/wickedyoda/Yacht/pull/105) ([SelfhostedPro](https://github.com/wickedyoda))
-- Update README.md [\#99](https://github.com/wickedyoda/Yacht/pull/99) ([SelfhostedPro](https://github.com/wickedyoda))
-- Sync Develop [\#96](https://github.com/wickedyoda/Yacht/pull/96) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixed stats by adding time back to them for individual apps [\#191](https://github.com/Yacht-sh/Yacht/pull/191) ([SelfhostedPro](https://github.com/wickedyoda))
+- added none restart policy [\#190](https://github.com/Yacht-sh/Yacht/pull/190) ([SelfhostedPro](https://github.com/wickedyoda))
+- Theming [\#189](https://github.com/Yacht-sh/Yacht/pull/189) ([SelfhostedPro](https://github.com/wickedyoda))
+- modified chart sizes [\#188](https://github.com/Yacht-sh/Yacht/pull/188) ([SelfhostedPro](https://github.com/wickedyoda))
+- Theming [\#187](https://github.com/Yacht-sh/Yacht/pull/187) ([SelfhostedPro](https://github.com/wickedyoda))
+- Theming [\#186](https://github.com/Yacht-sh/Yacht/pull/186) ([SelfhostedPro](https://github.com/wickedyoda))
+- Theming [\#185](https://github.com/Yacht-sh/Yacht/pull/185) ([SelfhostedPro](https://github.com/wickedyoda))
+- added digitalocean build [\#184](https://github.com/Yacht-sh/Yacht/pull/184) ([SelfhostedPro](https://github.com/wickedyoda))
+- Theming [\#183](https://github.com/Yacht-sh/Yacht/pull/183) ([SelfhostedPro](https://github.com/wickedyoda))
+- \[Snyk\] Security upgrade chart.js from 2.9.3 to 2.9.4 [\#181](https://github.com/Yacht-sh/Yacht/pull/181) ([snyk-bot](https://github.com/snyk-bot))
+- Alpha 4 Hotfix 1 \(v0.0.4-hf1\) [\#180](https://github.com/Yacht-sh/Yacht/pull/180) ([SelfhostedPro](https://github.com/wickedyoda))
+- Theming [\#179](https://github.com/Yacht-sh/Yacht/pull/179) ([SelfhostedPro](https://github.com/wickedyoda))
+- added rstrip to refresh\_template [\#178](https://github.com/Yacht-sh/Yacht/pull/178) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixing error handling on template variables [\#177](https://github.com/Yacht-sh/Yacht/pull/177) ([SelfhostedPro](https://github.com/wickedyoda))
+- changed conv\_ports2dict to check for the length before checking the d… [\#176](https://github.com/Yacht-sh/Yacht/pull/176) ([SelfhostedPro](https://github.com/wickedyoda))
+- troubleshooting templates and template variables [\#175](https://github.com/Yacht-sh/Yacht/pull/175) ([SelfhostedPro](https://github.com/wickedyoda))
+- Error handling [\#174](https://github.com/Yacht-sh/Yacht/pull/174) ([SelfhostedPro](https://github.com/wickedyoda))
 
-## [v0.01-alpha](https://github.com/wickedyoda/Yacht/tree/v0.01-alpha) (2020-09-23)
+## [v0.0.4-alpha](https://github.com/Yacht-sh/Yacht/tree/v0.0.4-alpha) (2020-10-17)
 
-[Full Changelog](https://github.com/wickedyoda/Yacht/compare/v0.0.1-prealpha...v0.01-alpha)
+[Full Changelog](https://github.com/Yacht-sh/Yacht/compare/v0.0.3-alpha-hf1...v0.0.4-alpha)
 
 **Implemented enhancements:**
 
-- \[Feature Request\] Docker image pruning [\#66](https://github.com/wickedyoda/Yacht/issues/66)
-- \[Feature Request\] Rebuild app using vue for the front end. [\#60](https://github.com/wickedyoda/Yacht/issues/60)
-- \[Feature Request\] Feedback when deploying an app. [\#41](https://github.com/wickedyoda/Yacht/issues/41)
-- \[Feature Request\] automatically update status [\#36](https://github.com/wickedyoda/Yacht/issues/36)
-
-**Fixed bugs:**
-
-- \[BUG\] Templates with no host port set will fail to deploy. [\#62](https://github.com/wickedyoda/Yacht/issues/62)
+- \[Feature Request\] Customizable column views in "View Applications"-page [\#102](https://github.com/Yacht-sh/Yacht/issues/102)
 
 **Closed issues:**
 
-- \[Feature Request\] YAML compatibility for templates [\#74](https://github.com/wickedyoda/Yacht/issues/74)
-- Templates issue [\#71](https://github.com/wickedyoda/Yacht/issues/71)
-- Adding env variable breaks deployment [\#68](https://github.com/wickedyoda/Yacht/issues/68)
-- Dashboard Ideas [\#64](https://github.com/wickedyoda/Yacht/issues/64)
-- Buttons to add fields to ports and env sections. [\#11](https://github.com/wickedyoda/Yacht/issues/11)
+-  Internal Server Error: error while creating mount source path '/yacht/AppData/Config/Heimdall': mkdir /yacht: read-only file system  [\#160](https://github.com/Yacht-sh/Yacht/issues/160)
+- Issue with Yacht dashboard - Exceeding the max Dokcer count - I think. [\#145](https://github.com/Yacht-sh/Yacht/issues/145)
+- Can't View dashboard anymore [\#137](https://github.com/Yacht-sh/Yacht/issues/137)
+- \[Feature Request\] Show Stack/Compose a container belongs to in "View Application"-page [\#101](https://github.com/Yacht-sh/Yacht/issues/101)
+- Websockets not working behind reverse proxy [\#72](https://github.com/Yacht-sh/Yacht/issues/72)
 
 **Merged pull requests:**
 
-- Develop [\#94](https://github.com/wickedyoda/Yacht/pull/94) ([SelfhostedPro](https://github.com/wickedyoda))
-- Added link to app from dashboard [\#91](https://github.com/wickedyoda/Yacht/pull/91) ([SelfhostedPro](https://github.com/wickedyoda))
-- Update develop [\#90](https://github.com/wickedyoda/Yacht/pull/90) ([SelfhostedPro](https://github.com/wickedyoda))
-- App list [\#89](https://github.com/wickedyoda/Yacht/pull/89) ([SelfhostedPro](https://github.com/wickedyoda))
-- Develop [\#85](https://github.com/wickedyoda/Yacht/pull/85) ([SelfhostedPro](https://github.com/wickedyoda))
-- updated dependancies; changed size of graphs on dashboard; fixed lint… [\#84](https://github.com/wickedyoda/Yacht/pull/84) ([SelfhostedPro](https://github.com/wickedyoda))
-- Dashboard [\#83](https://github.com/wickedyoda/Yacht/pull/83) ([SelfhostedPro](https://github.com/wickedyoda))
-- \[Snyk\] Upgrade vuetify from 2.3.9 to 2.3.10 [\#82](https://github.com/wickedyoda/Yacht/pull/82) ([snyk-bot](https://github.com/snyk-bot))
-- \[Snyk\] Upgrade vue-chartjs from 3.5.0 to 3.5.1 [\#80](https://github.com/wickedyoda/Yacht/pull/80) ([snyk-bot](https://github.com/snyk-bot))
-- \[Snyk\] Upgrade axios from 0.19.2 to 0.20.0 [\#79](https://github.com/wickedyoda/Yacht/pull/79) ([snyk-bot](https://github.com/snyk-bot))
-- \[Snyk\] Security upgrade sqlalchemy from 1.3.18 to 1.3.19 [\#78](https://github.com/wickedyoda/Yacht/pull/78) ([snyk-bot](https://github.com/snyk-bot))
-- added removal of whitespace to the right of a template URL to prevent… [\#76](https://github.com/wickedyoda/Yacht/pull/76) ([SelfhostedPro](https://github.com/wickedyoda))
-- yaml templates are working now [\#75](https://github.com/wickedyoda/Yacht/pull/75) ([SelfhostedPro](https://github.com/wickedyoda))
-- Vue charts [\#70](https://github.com/wickedyoda/Yacht/pull/70) ([SelfhostedPro](https://github.com/wickedyoda))
-- added total memory to stats page [\#69](https://github.com/wickedyoda/Yacht/pull/69) ([SelfhostedPro](https://github.com/wickedyoda))
-- Vue charts [\#67](https://github.com/wickedyoda/Yacht/pull/67) ([SelfhostedPro](https://github.com/wickedyoda))
+- added proxy read timeout [\#172](https://github.com/Yacht-sh/Yacht/pull/172) ([SelfhostedPro](https://github.com/wickedyoda))
+- added network\_mode to templates and db [\#171](https://github.com/Yacht-sh/Yacht/pull/171) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixed app update issue; fixed 422 error on page load \(checks for auth… [\#170](https://github.com/Yacht-sh/Yacht/pull/170) ([SelfhostedPro](https://github.com/wickedyoda))
+- added error check to the check\_updates function if it's not able to g… [\#169](https://github.com/Yacht-sh/Yacht/pull/169) ([SelfhostedPro](https://github.com/wickedyoda))
+- removed volumes from deploy form to prevent confusion [\#168](https://github.com/Yacht-sh/Yacht/pull/168) ([SelfhostedPro](https://github.com/wickedyoda))
+- added error handling to image methods [\#167](https://github.com/Yacht-sh/Yacht/pull/167) ([SelfhostedPro](https://github.com/wickedyoda))
+- added network and network\_mode to the deploy form; added a drop down … [\#166](https://github.com/Yacht-sh/Yacht/pull/166) ([SelfhostedPro](https://github.com/wickedyoda))
+- removed required indicator from ipv4 fields [\#165](https://github.com/Yacht-sh/Yacht/pull/165) ([SelfhostedPro](https://github.com/wickedyoda))
+- added better network error handling; formatted all the python stuff w... [\#164](https://github.com/Yacht-sh/Yacht/pull/164) ([SelfhostedPro](https://github.com/wickedyoda))
+- Added network creation form [\#163](https://github.com/Yacht-sh/Yacht/pull/163) ([SelfhostedPro](https://github.com/wickedyoda))
+- added basic network managment \(other than creating\) [\#162](https://github.com/Yacht-sh/Yacht/pull/162) ([SelfhostedPro](https://github.com/wickedyoda))
+- Added image and volume management [\#161](https://github.com/Yacht-sh/Yacht/pull/161) ([SelfhostedPro](https://github.com/wickedyoda))
+- modified images to not show test builds; fixed issue with image detai… [\#158](https://github.com/Yacht-sh/Yacht/pull/158) ([SelfhostedPro](https://github.com/wickedyoda))
+- Disable Auth Variable [\#154](https://github.com/Yacht-sh/Yacht/pull/154) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixed updating template list on delete [\#153](https://github.com/Yacht-sh/Yacht/pull/153) ([SelfhostedPro](https://github.com/wickedyoda))
+- Image Managment [\#152](https://github.com/Yacht-sh/Yacht/pull/152) ([SelfhostedPro](https://github.com/wickedyoda))
+- \[Snyk\] Security upgrade passlib from 1.7.2 to 1.7.3 [\#150](https://github.com/Yacht-sh/Yacht/pull/150) ([snyk-bot](https://github.com/snyk-bot))
+- added notes to deploy form [\#149](https://github.com/Yacht-sh/Yacht/pull/149) ([SelfhostedPro](https://github.com/wickedyoda))
+- Alpha 4 \(v0.0.4-alpha\) [\#147](https://github.com/Yacht-sh/Yacht/pull/147) ([SelfhostedPro](https://github.com/wickedyoda))
+- added filterable columns [\#146](https://github.com/Yacht-sh/Yacht/pull/146) ([SelfhostedPro](https://github.com/wickedyoda))
 
-## [v0.0.1-prealpha](https://github.com/wickedyoda/Yacht/tree/v0.0.1-prealpha) (2020-08-01)
+## [v0.0.3-alpha-hf1](https://github.com/Yacht-sh/Yacht/tree/v0.0.3-alpha-hf1) (2020-10-03)
 
-[Full Changelog](https://github.com/wickedyoda/Yacht/compare/v0.1a1...v0.0.1-prealpha)
-
-**Fixed bugs:**
-
-- \[BUG\] Unspecified ports cause 500 error [\#34](https://github.com/wickedyoda/Yacht/issues/34)
-- Yacht Page doesn't load on trying to install calibre-web [\#30](https://github.com/wickedyoda/Yacht/issues/30)
-- \[BUG\] - Preset environment variable isn't brought in, env variable name is blank [\#29](https://github.com/wickedyoda/Yacht/issues/29)
-- Misleading "Add New Apps" button sub header [\#27](https://github.com/wickedyoda/Yacht/issues/27)
-- \[BUG\] 500 Internal server error on login page [\#26](https://github.com/wickedyoda/Yacht/issues/26)
+[Full Changelog](https://github.com/Yacht-sh/Yacht/compare/v0.0.3-alpha...v0.0.3-alpha-hf1)
 
 **Closed issues:**
 
-- 500 Error when changing email address [\#21](https://github.com/wickedyoda/Yacht/issues/21)
-- Apps: [\#6](https://github.com/wickedyoda/Yacht/issues/6)
-- Templates: [\#5](https://github.com/wickedyoda/Yacht/issues/5)
+- \[Feature Request\] Add Container Controllbuttons inside the App Page [\#135](https://github.com/Yacht-sh/Yacht/issues/135)
 
-## [v0.1a1](https://github.com/wickedyoda/Yacht/tree/v0.1a1) (2020-06-25)
+**Merged pull requests:**
 
-[Full Changelog](https://github.com/wickedyoda/Yacht/compare/717203eef534db09937dc29d0d9930bb133c7ddf...v0.1a1)
+- Hotfix [\#143](https://github.com/Yacht-sh/Yacht/pull/143) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixed update functionality for if image is missing [\#142](https://github.com/Yacht-sh/Yacht/pull/142) ([SelfhostedPro](https://github.com/wickedyoda))
+
+## [v0.0.3-alpha](https://github.com/Yacht-sh/Yacht/tree/v0.0.3-alpha) (2020-10-03)
+
+[Full Changelog](https://github.com/Yacht-sh/Yacht/compare/v0.0.1-alpha...v0.0.3-alpha)
+
+**Implemented enhancements:**
+
+- \[Feature Request\] Add container label support [\#106](https://github.com/Yacht-sh/Yacht/issues/106)
+
+**Fixed bugs:**
+
+- docker stats reported as null for ARM [\#115](https://github.com/Yacht-sh/Yacht/issues/115)
+
+**Closed issues:**
+
+- \[Feature Request\] Ability to pull & deploy new \(latest\) image of a already deployed container [\#131](https://github.com/Yacht-sh/Yacht/issues/131)
+- Add devices section to templates [\#88](https://github.com/Yacht-sh/Yacht/issues/88)
+
+**Merged pull requests:**
+
+- Alpha 3 \(v0.0.3-alpha\) Update [\#141](https://github.com/Yacht-sh/Yacht/pull/141) ([SelfhostedPro](https://github.com/wickedyoda))
+- added check to see if templates list is empty and prompt to add a tem… [\#140](https://github.com/Yacht-sh/Yacht/pull/140) ([SelfhostedPro](https://github.com/wickedyoda))
+- Updating [\#139](https://github.com/Yacht-sh/Yacht/pull/139) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixed issue where Yacht wouldn't show it's updatable even if there's … [\#138](https://github.com/Yacht-sh/Yacht/pull/138) ([SelfhostedPro](https://github.com/wickedyoda))
+- added app actions to app details page [\#136](https://github.com/Yacht-sh/Yacht/pull/136) ([SelfhostedPro](https://github.com/wickedyoda))
+- added update checks [\#134](https://github.com/Yacht-sh/Yacht/pull/134) ([SelfhostedPro](https://github.com/wickedyoda))
+- working on ability to check for updates [\#133](https://github.com/Yacht-sh/Yacht/pull/133) ([SelfhostedPro](https://github.com/wickedyoda))
+- Error Handling [\#132](https://github.com/Yacht-sh/Yacht/pull/132) ([SelfhostedPro](https://github.com/wickedyoda))
+- Updating [\#129](https://github.com/Yacht-sh/Yacht/pull/129) ([SelfhostedPro](https://github.com/wickedyoda))
+- changed to using watchtower from custom solution [\#128](https://github.com/Yacht-sh/Yacht/pull/128) ([SelfhostedPro](https://github.com/wickedyoda))
+- fixed update ports [\#127](https://github.com/Yacht-sh/Yacht/pull/127) ([SelfhostedPro](https://github.com/wickedyoda))
+- added self update ability [\#126](https://github.com/Yacht-sh/Yacht/pull/126) ([SelfhostedPro](https://github.com/wickedyoda))
+- disable updating yacht from yacht [\#125](https://github.com/Yacht-sh/Yacht/pull/125) ([SelfhostedPro](https://github.com/wickedyoda))
+- Updating [\#124](https://github.com/Yacht-sh/Yacht/pull/124) ([SelfhostedPro](https://github.com/wickedyoda))
+- removed purge from serverinfo [\#123](https://github.com/Yacht-sh/Yacht/pull/123) ([SelfhostedPro](https://github.com/wickedyoda))
+- added separate buttons for purging and added snack for number of item… [\#122](https://github.com/Yacht-sh/Yacht/pull/122) ([SelfhostedPro](https://github.com/wickedyoda))
+
+## [v0.0.1-alpha](https://github.com/Yacht-sh/Yacht/tree/v0.0.1-alpha) (2020-09-26)
+
+[Full Changelog](https://github.com/Yacht-sh/Yacht/compare/v0.0.2-alpha...v0.0.1-alpha)
+
+## [v0.0.2-alpha](https://github.com/Yacht-sh/Yacht/tree/v0.0.2-alpha) (2020-09-26)
+
+[Full Changelog](https://github.com/Yacht-sh/Yacht/compare/v0.01-alpha...v0.0.2-alpha)
+
+**Implemented enhancements:**
+
+- \[Feature Request\] Expand View Applications page [\#77](https://github.com/Yacht-sh/Yacht/issues/77)
+
+**Closed issues:**
+
+- \[Feature Request\] Container start line storage [\#112](https://github.com/Yacht-sh/Yacht/issues/112)
+- Support for Docker Socket Proxy [\#107](https://github.com/Yacht-sh/Yacht/issues/107)
+- Crash on start [\#104](https://github.com/Yacht-sh/Yacht/issues/104)
+- \[Feature Request\] Ports in "View Application"-page [\#100](https://github.com/Yacht-sh/Yacht/issues/100)
+- Max CPU showing above 100% [\#97](https://github.com/Yacht-sh/Yacht/issues/97)
+- \[Feature Request\] Move the port link to the apps page [\#87](https://github.com/Yacht-sh/Yacht/issues/87)
+- \[Feature Request\] Port Descriptions [\#73](https://github.com/Yacht-sh/Yacht/issues/73)
+
+**Merged pull requests:**
+
+- change mem variables to None if they aren't reported by docker [\#120](https://github.com/Yacht-sh/Yacht/pull/120) ([SelfhostedPro](https://github.com/wickedyoda))
+- added github link and troubleshooting problem [\#119](https://github.com/Yacht-sh/Yacht/pull/119) ([SelfhostedPro](https://github.com/wickedyoda))
+- Port labels [\#118](https://github.com/Yacht-sh/Yacht/pull/118) ([SelfhostedPro](https://github.com/wickedyoda))
+- linted and auto-fixed [\#117](https://github.com/Yacht-sh/Yacht/pull/117) ([SelfhostedPro](https://github.com/wickedyoda))
+- improved error reporting on container deployment and fixed labels [\#116](https://github.com/Yacht-sh/Yacht/pull/116) ([SelfhostedPro](https://github.com/wickedyoda))
+- added check for alembiic versions folder [\#114](https://github.com/Yacht-sh/Yacht/pull/114) ([SelfhostedPro](https://github.com/wickedyoda))
+- Port labels [\#111](https://github.com/Yacht-sh/Yacht/pull/111) ([SelfhostedPro](https://github.com/wickedyoda))
+- Merge Develop [\#110](https://github.com/Yacht-sh/Yacht/pull/110) ([SelfhostedPro](https://github.com/wickedyoda))
+- Port labels [\#109](https://github.com/Yacht-sh/Yacht/pull/109) ([SelfhostedPro](https://github.com/wickedyoda))
+- Fix nginx config not copying correctly on NAS OSs [\#105](https://github.com/Yacht-sh/Yacht/pull/105) ([SelfhostedPro](https://github.com/wickedyoda))
+- Update README.md [\#99](https://github.com/Yacht-sh/Yacht/pull/99) ([SelfhostedPro](https://github.com/wickedyoda))
+- Sync Develop [\#96](https://github.com/Yacht-sh/Yacht/pull/96) ([SelfhostedPro](https://github.com/wickedyoda))
+
+## [v0.01-alpha](https://github.com/Yacht-sh/Yacht/tree/v0.01-alpha) (2020-09-23)
+
+[Full Changelog](https://github.com/Yacht-sh/Yacht/compare/v0.0.1-prealpha...v0.01-alpha)
+
+**Implemented enhancements:**
+
+- \[Feature Request\] Docker image pruning [\#66](https://github.com/Yacht-sh/Yacht/issues/66)
+- \[Feature Request\] Rebuild app using vue for the front end. [\#60](https://github.com/Yacht-sh/Yacht/issues/60)
+- \[Feature Request\] Feedback when deploying an app. [\#41](https://github.com/Yacht-sh/Yacht/issues/41)
+- \[Feature Request\] automatically update status [\#36](https://github.com/Yacht-sh/Yacht/issues/36)
+
+**Fixed bugs:**
+
+- \[BUG\] Templates with no host port set will fail to deploy. [\#62](https://github.com/Yacht-sh/Yacht/issues/62)
+
+**Closed issues:**
+
+- \[Feature Request\] YAML compatibility for templates [\#74](https://github.com/Yacht-sh/Yacht/issues/74)
+- Templates issue [\#71](https://github.com/Yacht-sh/Yacht/issues/71)
+- Adding env variable breaks deployment [\#68](https://github.com/Yacht-sh/Yacht/issues/68)
+- Dashboard Ideas [\#64](https://github.com/Yacht-sh/Yacht/issues/64)
+- Buttons to add fields to ports and env sections. [\#11](https://github.com/Yacht-sh/Yacht/issues/11)
+
+**Merged pull requests:**
+
+- Develop [\#94](https://github.com/Yacht-sh/Yacht/pull/94) ([SelfhostedPro](https://github.com/wickedyoda))
+- Added link to app from dashboard [\#91](https://github.com/Yacht-sh/Yacht/pull/91) ([SelfhostedPro](https://github.com/wickedyoda))
+- Update develop [\#90](https://github.com/Yacht-sh/Yacht/pull/90) ([SelfhostedPro](https://github.com/wickedyoda))
+- App list [\#89](https://github.com/Yacht-sh/Yacht/pull/89) ([SelfhostedPro](https://github.com/wickedyoda))
+- Develop [\#85](https://github.com/Yacht-sh/Yacht/pull/85) ([SelfhostedPro](https://github.com/wickedyoda))
+- updated dependancies; changed size of graphs on dashboard; fixed lint… [\#84](https://github.com/Yacht-sh/Yacht/pull/84) ([SelfhostedPro](https://github.com/wickedyoda))
+- Dashboard [\#83](https://github.com/Yacht-sh/Yacht/pull/83) ([SelfhostedPro](https://github.com/wickedyoda))
+- \[Snyk\] Upgrade vuetify from 2.3.9 to 2.3.10 [\#82](https://github.com/Yacht-sh/Yacht/pull/82) ([snyk-bot](https://github.com/snyk-bot))
+- \[Snyk\] Upgrade vue-chartjs from 3.5.0 to 3.5.1 [\#80](https://github.com/Yacht-sh/Yacht/pull/80) ([snyk-bot](https://github.com/snyk-bot))
+- \[Snyk\] Upgrade axios from 0.19.2 to 0.20.0 [\#79](https://github.com/Yacht-sh/Yacht/pull/79) ([snyk-bot](https://github.com/snyk-bot))
+- \[Snyk\] Security upgrade sqlalchemy from 1.3.18 to 1.3.19 [\#78](https://github.com/Yacht-sh/Yacht/pull/78) ([snyk-bot](https://github.com/snyk-bot))
+- added removal of whitespace to the right of a template URL to prevent… [\#76](https://github.com/Yacht-sh/Yacht/pull/76) ([SelfhostedPro](https://github.com/wickedyoda))
+- yaml templates are working now [\#75](https://github.com/Yacht-sh/Yacht/pull/75) ([SelfhostedPro](https://github.com/wickedyoda))
+- Vue charts [\#70](https://github.com/Yacht-sh/Yacht/pull/70) ([SelfhostedPro](https://github.com/wickedyoda))
+- added total memory to stats page [\#69](https://github.com/Yacht-sh/Yacht/pull/69) ([SelfhostedPro](https://github.com/wickedyoda))
+- Vue charts [\#67](https://github.com/Yacht-sh/Yacht/pull/67) ([SelfhostedPro](https://github.com/wickedyoda))
+
+## [v0.0.1-prealpha](https://github.com/Yacht-sh/Yacht/tree/v0.0.1-prealpha) (2020-08-01)
+
+[Full Changelog](https://github.com/Yacht-sh/Yacht/compare/v0.1a1...v0.0.1-prealpha)
+
+**Fixed bugs:**
+
+- \[BUG\] Unspecified ports cause 500 error [\#34](https://github.com/Yacht-sh/Yacht/issues/34)
+- Yacht Page doesn't load on trying to install calibre-web [\#30](https://github.com/Yacht-sh/Yacht/issues/30)
+- \[BUG\] - Preset environment variable isn't brought in, env variable name is blank [\#29](https://github.com/Yacht-sh/Yacht/issues/29)
+- Misleading "Add New Apps" button sub header [\#27](https://github.com/Yacht-sh/Yacht/issues/27)
+- \[BUG\] 500 Internal server error on login page [\#26](https://github.com/Yacht-sh/Yacht/issues/26)
+
+**Closed issues:**
+
+- 500 Error when changing email address [\#21](https://github.com/Yacht-sh/Yacht/issues/21)
+- Apps: [\#6](https://github.com/Yacht-sh/Yacht/issues/6)
+- Templates: [\#5](https://github.com/Yacht-sh/Yacht/issues/5)
+
+## [v0.1a1](https://github.com/Yacht-sh/Yacht/tree/v0.1a1) (2020-06-25)
+
+[Full Changelog](https://github.com/Yacht-sh/Yacht/compare/717203eef534db09937dc29d0d9930bb133c7ddf...v0.1a1)
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![logo](https://raw.githubusercontent.com/wickedyoda/Yacht/master/readme_media/Yacht_logo_1_dark.png "templates")
+![logo](https://raw.githubusercontent.com/Yacht-sh/Yacht/master/readme_media/Yacht_logo_1_dark.png "templates")
 
 ### I am currently working on this repo to bring it up to date, patience and we will get there soon. 
 ### wickedyoda
@@ -9,7 +9,7 @@ Yacht is a container management UI with a focus on templates and 1-click deploym
 
 **I'm currently rewriting the backend in Typescript as an attempt to have a language that more people would contribute to. You can follow development of that [here](https://github.com/wickedyoda/yacht-nuxt).**
 
-![Tempaltes](https://raw.githubusercontent.com/Wickedyoda/Yacht/master/readme_media/Yacht-Demo.gif "templates")
+![Tempaltes](https://raw.githubusercontent.com/Yacht-sh/Yacht/master/readme_media/Yacht-Demo.gif "templates")
 
 ## Installation:
 

--- a/changes.md
+++ b/changes.md
@@ -1,14 +1,14 @@
-# 🔀 Pull Request Proposal: Merge `wickedyoda/yacht` Improvements into `SelfhostedPro/yacht`
+# 🔀 Pull Request Proposal: Merge `Yacht-sh/Yacht` Improvements into `Yacht-sh/Yacht`
 
 ## 🧠 Summary
 
-This pull request introduces substantial architectural and security improvements to the Yacht project. The fork maintained at `wickedyoda/yacht` shifts the backend toward a TypeScript-based implementation while preserving core frontend functionality. These changes improve code maintainability, modernize the development experience, and provide a more scalable foundation.
+This pull request introduces substantial architectural and security improvements to the Yacht project. The fork maintained at `Yacht-sh/Yacht` shifts the backend toward a TypeScript-based implementation while preserving core frontend functionality. These changes improve code maintainability, modernize the development experience, and provide a more scalable foundation.
 
 ---
 
 ## ✅ Key Differences
 
-| Category           | `SelfhostedPro/yacht`                      | `wickedyoda/yacht`                                  |
+| Category           | `Yacht-sh/Yacht`                      | `Yacht-sh/Yacht`                                  |
 |--------------------|--------------------------------------------|------------------------------------------------------|
 | **Backend**        | Python (Flask)                             | TypeScript (Node.js with Express)                   |
 | **Front-end**      | Vue.js                                     | Vue.js (retained, potentially updated)              |
@@ -60,7 +60,7 @@ This pull request introduces substantial architectural and security improvements
 
 ---
 
-**GitHub:** https://github.com/wickedyoda/yacht
+**GitHub:** https://github.com/Yacht-sh/Yacht
 
 ## 📜 Extended Summary
 

--- a/frontend/src/components/nav/Sidebar.vue
+++ b/frontend/src/components/nav/Sidebar.vue
@@ -51,7 +51,7 @@
         <v-icon size="200%" class="pa-2">mdi-file-document</v-icon>
       </a>
       <br />
-      <a :href="'https://' + 'github.com/wickedyoda/Yacht'">
+      <a :href="'https://' + 'github.com/Yacht-sh/Yacht'">
         <v-icon size="200%" class="pa-2">mdi-github</v-icon>
       </a>
     </template>


### PR DESCRIPTION
## Summary
- update docs and code references to old repos
- fix sidebar link to new github repo

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_686357480dec8323811a49419e15868f