### PR TITLE
[codex] Simplify GHCR publishing to master only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,12 @@
-name: Build And Publish Images
+name: Verify And Publish Main Image
 
 on:
   push:
     branches:
       - master
-      - develop
-  workflow_dispatch:
 
 concurrency:
-  group: image-publish-${{ github.ref_name }}
+  group: master-image-publish
   cancel-in-progress: true
 
 permissions:
@@ -176,24 +174,12 @@ jobs:
       - name: Prepare image metadata
         id: prep
         run: |
-          timestamp="$(date -u +%Y%m%d-%H%M%S)"
-          if [ "${GITHUB_REF_NAME}" = "master" ]; then
-            channel_tag="latest"
-            version_tag="${timestamp}"
-            app_version="${timestamp}"
-          elif [ "${GITHUB_REF_NAME}" = "develop" ]; then
-            channel_tag="dev-latest"
-            version_tag="dev-${timestamp}"
-            app_version="dev-${timestamp}"
-          else
-            echo "Unsupported ref ${GITHUB_REF_NAME}" >&2
-            exit 1
-          fi
+          short_sha="${GITHUB_SHA::12}"
 
           {
-            echo "channel_tag=${channel_tag}"
-            echo "version_tag=${version_tag}"
-            echo "app_version=${app_version}"
+            echo "channel_tag=latest"
+            echo "version_tag=sha-${short_sha}"
+            echo "app_version=${short_sha}"
             echo "owner_lc=${GITHUB_REPOSITORY_OWNER,,}"
           } >> "$GITHUB_OUTPUT"
 
@@ -235,79 +221,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=main-image-${{ github.ref_name }}
           cache-to: type=gha,mode=max,scope=main-image-${{ github.ref_name }}
-          provenance: mode=max
-          sbom: true
-
-  publish-agent-image:
-    name: Publish Agent Image
-    runs-on: ubuntu-latest
-    needs:
-      - verify-agent
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Prepare image metadata
-        id: prep
-        run: |
-          timestamp="$(date -u +%Y%m%d-%H%M%S)"
-          if [ "${GITHUB_REF_NAME}" = "master" ]; then
-            channel_tag="latest"
-            version_tag="${timestamp}"
-          elif [ "${GITHUB_REF_NAME}" = "develop" ]; then
-            channel_tag="dev-latest"
-            version_tag="dev-${timestamp}"
-          else
-            echo "Unsupported ref ${GITHUB_REF_NAME}" >&2
-            exit 1
-          fi
-
-          {
-            echo "channel_tag=${channel_tag}"
-            echo "version_tag=${version_tag}"
-            echo "owner_lc=${GITHUB_REPOSITORY_OWNER,,}"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Extract image metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ steps.prep.outputs.owner_lc }}/yacht-agent
-          tags: |
-            type=raw,value=${{ steps.prep.outputs.channel_tag }}
-            type=raw,value=${{ steps.prep.outputs.version_tag }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME != '' && secrets.GHCR_USERNAME || github.actor }}
-          password: ${{ secrets.GHCR_TOKEN != '' && secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
-
-      - name: Build and push agent image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./agent/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=agent-image-${{ github.ref_name }}
-          cache-to: type=gha,mode=max,scope=agent-image-${{ github.ref_name }}
           provenance: mode=max
           sbom: true

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,4 +1,4 @@
-# CI/CD and Image Publishing
+# CI/CD and Main Image Publishing
 
 ## Registries
 
@@ -8,10 +8,6 @@ Main image:
 
 - `ghcr.io/<owner>/yacht`
 
-Agent image:
-
-- `ghcr.io/<owner>/yacht-agent`
-
 ## Workflow
 
 Current image publishing uses:
@@ -20,9 +16,7 @@ Current image publishing uses:
 
 Trigger:
 
-- push to `develop`
 - push to `master`
-- manual dispatch
 
 ## Verification Stages
 
@@ -43,19 +37,10 @@ Before publishing, the workflow verifies:
 
 ## Publish Tags
 
-On `develop`:
-
-- `yacht:dev-latest`
-- `yacht:dev-<YYYYMMDD-HHMMSS>`
-- `yacht-agent:dev-latest`
-- `yacht-agent:dev-<YYYYMMDD-HHMMSS>`
-
-On `master`:
+On each push to `master`:
 
 - `yacht:latest`
-- `yacht:<YYYYMMDD-HHMMSS>`
-- `yacht-agent:latest`
-- `yacht-agent:<YYYYMMDD-HHMMSS>`
+- `yacht:sha-<12-char-commit-sha>`
 
 ## Supply Chain Metadata
 
@@ -71,4 +56,4 @@ The workflows log in to GHCR with:
 - `GHCR_USERNAME` and `GHCR_TOKEN` when provided
 - otherwise `github.actor` and `GITHUB_TOKEN`
 
-There is no Docker Hub publishing path in the current repo configuration.
+There is no Docker Hub publishing path in the current repo configuration, and the workflow no longer publishes a separate agent image.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -42,6 +42,15 @@ On each push to `master`:
 - `yacht:latest`
 - `yacht:sha-<12-char-commit-sha>`
 
+## Target Platforms
+
+The published main image targets:
+
+- `linux/amd64`
+- `linux/arm64`
+
+The workflow does not publish `arm/v7`.
+
 ## Supply Chain Metadata
 
 Current Docker build jobs enable:


### PR DESCRIPTION
## Summary
- keep the existing verification jobs
- publish only the main GHCR image on pushes to `master`
- remove the old multi-branch and agent-image publishing paths

## What changed
- workflow now triggers only on `master` pushes
- removed manual dispatch from the image publish workflow
- removed the separate `yacht-agent` publish job
- simplified the main image tags to:
  - `latest`
  - `sha-<12-char-commit-sha>`
- updated CI/CD docs to match the new deployment flow

## Verification
- parse `.github/workflows/build.yml` with `PyYAML`
- `git diff --check`
- confirm there are no remaining `develop`, `workflow_dispatch`, `publish-agent-image`, `yacht-agent`, or `dev-latest` references in the workflow/docs
