### PR TITLE
Optimize runtime image and frontend icon payload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,9 @@ RUN npm ci --legacy-peer-deps --no-audit --no-fund
 COPY ./frontend/ ./
 RUN npm run build
 
-# Runtime image
-FROM python:3.11-slim AS deploy-stage
+# Build Python wheels in an isolated stage so compiler toolchains do not land in runtime.
+FROM python:3.11-slim AS python-wheel-builder
 
-ARG DOCKER_COMPOSE_VERSION=v2.40.3
-
-ENV PYTHONIOENCODING=UTF-8
-ENV THEME=Default
-ENV PYTHONPATH=/api
-
-WORKDIR /api
 COPY ./backend/requirements.txt ./
 
 RUN apt-get update && \
@@ -34,41 +27,40 @@ RUN apt-get update && \
     zlib1g-dev \
     libyaml-dev \
     python3-dev \
-    nginx \
-    curl \
     ca-certificates \
-    bash && \
+    && \
     rm -rf /var/lib/apt/lists/*
-
-RUN set -eux; \
-    arch="$(uname -m)"; \
-    case "${arch}" in \
-      x86_64) compose_arch="x86_64" ;; \
-      aarch64) compose_arch="aarch64" ;; \
-      armv7l) compose_arch="armv7" ;; \
-      armv6l) compose_arch="armv6" ;; \
-      ppc64le) compose_arch="ppc64le" ;; \
-      s390x) compose_arch="s390x" ;; \
-      riscv64) compose_arch="riscv64" ;; \
-      *) echo "Unsupported architecture: ${arch}" && exit 1 ;; \
-    esac; \
-    curl -fL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-${compose_arch}" -o /usr/local/bin/docker-compose; \
-    chmod +x /usr/local/bin/docker-compose
 
 RUN pip3 install --upgrade pip setuptools wheel && \
-    pip3 install --no-cache-dir -r requirements.txt && \
-    apt-get purge -y --auto-remove \
-      build-essential \
-      pkg-config \
-      libffi-dev \
-      libssl-dev \
-      libpq-dev \
-      default-libmysqlclient-dev \
-      libjpeg-dev \
-      zlib1g-dev \
-      libyaml-dev \
-      python3-dev && \
+    pip3 wheel --wheel-dir /wheels -r requirements.txt setuptools
+
+# Runtime image
+FROM python:3.11-slim AS deploy-stage
+
+ENV PYTHONIOENCODING=UTF-8
+ENV THEME=Default
+ENV PYTHONPATH=/api
+
+WORKDIR /api
+COPY ./backend/requirements.txt ./
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    nginx \
+    docker-compose \
+    ca-certificates \
+    bash \
+    libpq5 \
+    libmariadb3 \
+    libjpeg62-turbo \
+    && \
     rm -rf /var/lib/apt/lists/*
+
+COPY --from=python-wheel-builder /wheels /wheels
+
+RUN pip3 install --no-cache-dir --no-index --find-links=/wheels setuptools && \
+    pip3 install --no-cache-dir --no-index --find-links=/wheels -r requirements.txt && \
+    rm -rf /wheels
 
 RUN groupadd -r abc && useradd -r -g abc abc
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,7 +7,7 @@
     <title>Yacht</title>
     <link rel="manifest" crossorigin="use-credentials" href="<%= BASE_URL %>manifest.json" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@7.4.47/css/materialdesignicons.min.css">
     <link rel="apple-touch-icon" sizes="57x57" href="/img/icons/apple-touch-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="/img/icons/apple-touch-icon-60x60.png">
     <link rel="apple-touch-icon" sizes="72x72" href="/img/icons/apple-touch-icon-72x72.png">

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -18,6 +18,11 @@ Vue.use(VueChatScroll);
 
 Vue.config.productionTip = false;
 
+// Configure axios to send cookies with all requests
+axios.defaults.withCredentials = true;
+axios.defaults.xsrfCookieName = "csrf_access_token";
+axios.defaults.xsrfHeaderName = "X-CSRF-TOKEN";
+
 // Handle Token Refresh on 401
 function createAxiosResponseInterceptor() {
   const interceptor = axios.interceptors.response.use(

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -1,7 +1,6 @@
 import Vue from "vue";
 import Vuetify from "vuetify/lib";
 import { themeTheme } from "../config.js";
-import "@mdi/font/css/materialdesignicons.css";
 
 Vue.use(Vuetify);
 


### PR DESCRIPTION
## Summary
- switch the runtime image from a downloaded standalone compose binary to the distro docker-compose package
- keep setuptools available in runtime while preserving the wheel-builder layout
- stop bundling the MDI font CSS into the frontend app bundle and pin the CDN stylesheet version

## Verification
- `docker build -t yacht:local-test-optimized .`
- `docker run -d --name yacht-local-optimized -p 30082:8000 -v /var/run/docker.sock:/var/run/docker.sock yacht:local-test-optimized`
- `curl http://127.0.0.1:30082/` returned `200`
- `docker exec yacht-local-optimized docker-compose version`
- `docker buildx build --builder desktop-linux --platform linux/amd64,linux/arm64 --output type=oci,dest=/tmp/yacht-multiarch-optimized.oci .`
- `docker run --rm -v "$PWD/frontend:/app" -w /app node:20-bookworm-slim bash -lc "npm ci --legacy-peer-deps --no-audit --no-fund >/tmp/npm-ci.log && npm run lint"`
- `docker run --rm -v "$PWD/frontend:/app" -w /app node:20-bookworm-slim bash -lc "npm ci --legacy-peer-deps --no-audit --no-fund >/tmp/npm-ci.log && npm run build"`

## Measured impact
- local image size: `136796602` -> `130426844` bytes
- multi-arch OCI artifact: `256M`
- frontend vendor CSS: `773 KiB` (previous bundled-font build) -> `449 KiB`
- frontend app entrypoint: `1.17 MiB` after this change
