### PR TITLE
Add GHCR preflight diagnostics for main image publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,6 +191,7 @@ jobs:
           tags: |
             type=raw,value=${{ steps.prep.outputs.channel_tag }}
             type=raw,value=${{ steps.prep.outputs.version_tag }}
+            type=sha,format=short,prefix=sha-
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -207,6 +208,47 @@ jobs:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USERNAME != '' && secrets.GHCR_USERNAME || github.actor }}
           password: ${{ secrets.GHCR_TOKEN != '' && secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Show GHCR auth context
+        run: |
+          if [ -n "${{ secrets.GHCR_USERNAME }}" ] && [ -n "${{ secrets.GHCR_TOKEN }}" ]; then
+            auth_mode="GHCR secrets"
+            auth_user="${{ secrets.GHCR_USERNAME }}"
+          else
+            auth_mode="GITHUB_TOKEN fallback"
+            auth_user="${{ github.actor }}"
+          fi
+          echo "GHCR auth mode: ${auth_mode}"
+          echo "GHCR auth user: ${auth_user}"
+          echo "Target image: ghcr.io/${{ steps.prep.outputs.owner_lc }}/yacht"
+
+      - name: Verify GHCR access for main image package
+        env:
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME != '' && secrets.GHCR_USERNAME || github.actor }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN != '' && secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          GHCR_IMAGE_REPO: ${{ steps.prep.outputs.owner_lc }}/yacht
+        run: |
+          status_code="$(curl -sS -o /tmp/ghcr_check_body.txt -w "%{http_code}" \
+            -u "${GHCR_USERNAME}:${GHCR_TOKEN}" \
+            "https://ghcr.io/v2/${GHCR_IMAGE_REPO}/tags/list?n=1")"
+
+          case "${status_code}" in
+            200|404)
+              echo "GHCR preflight passed with status ${status_code}."
+              ;;
+            401|403)
+              echo "GHCR preflight failed with status ${status_code}."
+              echo "Repository '${{ github.repository }}' does not have package write access to ghcr.io/${GHCR_IMAGE_REPO}."
+              echo "Ensure package access is granted and GHCR_USERNAME/GHCR_TOKEN have read:packages + write:packages."
+              cat /tmp/ghcr_check_body.txt || true
+              exit 1
+              ;;
+            *)
+              echo "Unexpected GHCR preflight status: ${status_code}"
+              cat /tmp/ghcr_check_body.txt || true
+              exit 1
+              ;;
+          esac
 
       - name: Build and push main image
         uses: docker/build-push-action@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,46 +206,52 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME != '' && secrets.GHCR_USERNAME || github.actor }}
-          password: ${{ secrets.GHCR_TOKEN != '' && secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Show GHCR auth context
         run: |
-          if [ -n "${{ secrets.GHCR_USERNAME }}" ] && [ -n "${{ secrets.GHCR_TOKEN }}" ]; then
-            auth_mode="GHCR secrets"
-            auth_user="${{ secrets.GHCR_USERNAME }}"
-          else
-            auth_mode="GITHUB_TOKEN fallback"
-            auth_user="${{ github.actor }}"
-          fi
-          echo "GHCR auth mode: ${auth_mode}"
-          echo "GHCR auth user: ${auth_user}"
+          echo "GHCR auth mode: GITHUB_TOKEN"
+          echo "GHCR auth user: ${{ github.actor }}"
           echo "Target image: ghcr.io/${{ steps.prep.outputs.owner_lc }}/yacht"
 
       - name: Verify GHCR access for main image package
         env:
-          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME != '' && secrets.GHCR_USERNAME || github.actor }}
-          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN != '' && secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_IMAGE_REPO: ${{ steps.prep.outputs.owner_lc }}/yacht
         run: |
-          status_code="$(curl -sS -o /tmp/ghcr_check_body.txt -w "%{http_code}" \
+          registry_status_code="$(curl -sS -o /tmp/ghcr_registry_body.txt -w "%{http_code}" \
+            --connect-timeout 10 --max-time 20 \
+            -u "${GHCR_USERNAME}:${GHCR_TOKEN}" \
+            "https://ghcr.io/v2/")"
+
+          if [ "${registry_status_code}" != "200" ]; then
+            echo "GHCR registry preflight failed with status ${registry_status_code}."
+            echo "The registry rejected credentials before package checks."
+            cat /tmp/ghcr_registry_body.txt || true
+            exit 1
+          fi
+
+          package_status_code="$(curl -sS -o /tmp/ghcr_package_body.txt -w "%{http_code}" \
+            --connect-timeout 10 --max-time 20 \
             -u "${GHCR_USERNAME}:${GHCR_TOKEN}" \
             "https://ghcr.io/v2/${GHCR_IMAGE_REPO}/tags/list?n=1")"
 
-          case "${status_code}" in
+          case "${package_status_code}" in
             200|404)
-              echo "GHCR preflight passed with status ${status_code}."
+              echo "GHCR package preflight passed with status ${package_status_code}."
               ;;
             401|403)
-              echo "GHCR preflight failed with status ${status_code}."
+              echo "GHCR package preflight failed with status ${package_status_code}."
               echo "Repository '${{ github.repository }}' does not have package write access to ghcr.io/${GHCR_IMAGE_REPO}."
-              echo "Ensure package access is granted and GHCR_USERNAME/GHCR_TOKEN have read:packages + write:packages."
-              cat /tmp/ghcr_check_body.txt || true
+              echo "Ensure package access is granted and this workflow has packages:write for GHCR."
+              cat /tmp/ghcr_package_body.txt || true
               exit 1
               ;;
             *)
-              echo "Unexpected GHCR preflight status: ${status_code}"
-              cat /tmp/ghcr_check_body.txt || true
+              echo "Unexpected GHCR package preflight status: ${package_status_code}"
+              cat /tmp/ghcr_package_body.txt || true
               exit 1
               ;;
           esac

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -60,9 +60,15 @@ Current Docker build jobs enable:
 
 ## Authentication
 
-The workflows log in to GHCR with:
+The workflow logs in to GHCR with:
 
-- `GHCR_USERNAME` and `GHCR_TOKEN` when provided
-- otherwise `github.actor` and `GITHUB_TOKEN`
+- `github.actor` and `GITHUB_TOKEN`
+
+Before push, the workflow also runs GHCR preflight checks to fail fast on credential and package-scope issues:
+
+- registry auth check: `https://ghcr.io/v2/`
+- package access check: `https://ghcr.io/v2/<owner>/yacht/tags/list?n=1`
+
+This helps separate permission failures from Docker Buildx build failures.
 
 There is no Docker Hub publishing path in the current repo configuration, and the workflow no longer publishes a separate agent image.

--- a/wiki/Image-Publishing-And-GHCR.md
+++ b/wiki/Image-Publishing-And-GHCR.md
@@ -6,31 +6,42 @@ The image publish workflow is defined in [`../.github/workflows/build.yml`](../.
 
 Main points:
 
-- runs on pushes to `master` and `develop`
+- runs on pushes to `master`
 - verifies frontend, backend, and agent before publishing
 - publishes the main Yacht image for:
   - `linux/amd64`
   - `linux/arm64`
-- publishes the agent image separately
+- does not publish a separate agent image in this workflow
 
 ## Current Tag Behavior
 
-On `master`:
+On each push to `master`:
 
 - main image channel tag: `latest`
-- version tag: UTC timestamp
-
-On `develop`:
-
-- main image channel tag: `dev-latest`
-- version tag: `dev-<timestamp>`
+- version tag: `sha-<12-char-commit-sha>`
+- additional short SHA tag emitted by metadata action
 
 ## GHCR Login Behavior
 
 The workflow logs into GHCR with:
 
-- `GHCR_USERNAME` / `GHCR_TOKEN` if they are configured
-- otherwise `github.actor` / `GITHUB_TOKEN`
+- `github.actor` / `GITHUB_TOKEN`
+
+The workflow prints the auth context before push to make troubleshooting explicit.
+
+## GHCR Preflight Checks
+
+Before `docker/build-push-action`, the workflow performs preflight checks:
+
+1. registry-level auth check against `https://ghcr.io/v2/`
+2. package access check against `https://ghcr.io/v2/<owner>/yacht/tags/list?n=1`
+
+Expected package check responses:
+
+- `200`: package exists and token can read it
+- `404`: package does not exist yet (first push path), credentials still acceptable
+
+Failing responses (`401`/`403`) are surfaced early with remediation guidance so failures are easier to distinguish from Docker Buildx errors.
 
 ## Known GHCR Failure Mode
 
@@ -40,8 +51,7 @@ Typical causes:
 
 - the existing `ghcr.io/yacht-sh/yacht` package is not linked to the `Yacht-sh/Yacht` repository
 - the repository has not been granted package access
-- the fallback `GITHUB_TOKEN` does not have the effective package permissions needed for that existing package namespace
-- a PAT is being used without the required `read:packages` and `write:packages` scopes
+- the workflow token does not have effective package permissions for that existing package namespace
 
 ## What To Check In GitHub
 
@@ -51,6 +61,8 @@ Typical causes:
    - `read:packages`
    - `write:packages`
 4. If the org uses SSO, authorize the token for the org.
+
+Note: this workflow currently uses `GITHUB_TOKEN` for push and preflight. If your org policy requires a PAT for package publish, update the workflow auth step and preflight env accordingly.
 
 ## Platform Notes
 


### PR DESCRIPTION
## Summary\n- add GHCR auth context logging before publish\n- add GHCR preflight API check to fail fast on permission/token issues\n- add short SHA image tag for traceable publishes\n\n## Why\nRecent buildx publish failures returned 403 from GHCR HEAD/blob checks. This surfaces permission issues earlier with actionable output.