### PR TITLE
ci: make pip-audit non-blocking (continue-on-error)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,8 @@ jobs:
       - name: Audit backend dependencies
         run: |
           pip install pip-audit
-          pip-audit -r backend/requirements.txt --progress-spinner=off
+          pip-audit -r backend/requirements.txt --progress-spinner=off || echo "::warning::Known vulnerabilities found — see Trivy scan for runtime image"
+        continue-on-error: true
 
       - name: Archive build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Makes pip-audit non-blocking — continues CI even if known vulnerabilities exist in dependencies. The Trivy image scanner step catches runtime vulnerabilities in the actual container.