### PR TITLE
ci: use existing CR_PAT for GHCR authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.CR_PAT }}
 
       - name: Extract metadata
         id: meta


### PR DESCRIPTION
Use the existing CR_PAT secret (stored since 2021) for GHCR authentication instead of GHCR_PAT which was set with a GitHub App token lacking package write scopes.