### PR TITLE
ci: use GITHUB_TOKEN for GHCR auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta


### PR DESCRIPTION
Use built-in GITHUB_TOKEN for GHCR authentication instead of external PAT lacking write:packages scope.