### PR TITLE
ci: use CR_PAT for GHCR authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.CR_PAT }}
 
       - name: Extract metadata
         id: meta


### PR DESCRIPTION
Use the existing CR_PAT secret (from 2021, likely has write:packages scope) for GHCR authentication instead of GITHUB_TOKEN or the new GHCR_PAT.