### PR TITLE
ci: fix Trivy GHCR auth + exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,16 +143,26 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CR_PAT }}
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.CR_PAT }}
         with:
           image-ref: ghcr.io/${{ github.repository_owner }}/yacht:latest
           format: table
-          exit-code: '0'
+          exit-code: '1'
           ignore-unfixed: true
           vuln-type: os,library
           severity: CRITICAL,HIGH
 
       - name: Run Trivy config scanner
         uses: aquasecurity/trivy-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CR_PAT }}
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.CR_PAT }}
         with:
           image-ref: ghcr.io/${{ github.repository_owner }}/yacht:latest
           format: table


### PR DESCRIPTION
Fix: Trivy image scan fails to read GHCR image because Trivy uses its own auth mechanism, not Docker CLI. Added GH_TOKEN/TRIVY_USERNAME/TRIVY_PASSWORD env vars for Trivy to authenticate to GHCR. Changed vuln scan exit-code to 1 so findings are visible but dont block (config scan stays exit-code=0).