### PR TITLE
ci: fix Trivy lowercase org + scanners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,12 +149,13 @@ jobs:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.CR_PAT }}
         with:
-          image-ref: ghcr.io/${{ github.repository_owner }}/yacht:latest
+          image-ref: ghcr.io/yacht-sh/yacht:latest
           format: table
           exit-code: '1'
           ignore-unfixed: true
           vuln-type: os,library
           severity: CRITICAL,HIGH
+          scanners: vuln,config
 
       - name: Run Trivy config scanner
         uses: aquasecurity/trivy-action@master
@@ -164,8 +165,9 @@ jobs:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.CR_PAT }}
         with:
-          image-ref: ghcr.io/${{ github.repository_owner }}/yacht:latest
+          image-ref: ghcr.io/yacht-sh/yacht:latest
           format: table
           exit-code: '0'
           ignore-unfixed: true
           scan-type: config
+          scanners: misconfig


### PR DESCRIPTION
Fix: Trivy image scan failed because github.repository_owner returns Yacht-sh (capital Y) but GHCR uses lowercase yacht-sh. Using lowercase directly. Also added scanners parameter to avoid scan-type deprecation.