### PR TITLE
fix: revert starlette to 0.49.1

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,7 +34,7 @@ six==1.16.0
 sh==2.2.4
 # SQLAlchemy==2.0.20
 SQLAlchemy==1.4.41
-starlette==1.3.1
+starlette==0.49.1
 # sse-starlette==1.4.1 (wrong version cant deploy)
 sse-starlette==2.1.3
 typing-extensions==4.14.0


### PR DESCRIPTION
PR #863 bumped starlette to 1.3.1 but fastapi==0.120.4 requires starlette>=0.40.0,<0.50.0. Reverting to 0.49.1 to fix dependency conflict.