### PR TITLE
ci: fix Trivy config scanner scan type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,15 +159,10 @@ jobs:
 
       - name: Run Trivy config scanner
         uses: aquasecurity/trivy-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.CR_PAT }}
-          TRIVY_USERNAME: ${{ github.actor }}
-          TRIVY_PASSWORD: ${{ secrets.CR_PAT }}
         with:
-          image-ref: ghcr.io/yacht-sh/yacht:latest
+          scan-type: fs
+          scan-ref: '.'
           format: table
           exit-code: '0'
           ignore-unfixed: true
-          scan-type: config
           scanners: misconfig


### PR DESCRIPTION
The config scanner was using scan-type: config with an image-ref, but "trivy config" does filesystem scanning. Changed to scan-type: fs with scan-ref: "." to scan the repo files instead of trying to config-scan a Docker image.