### PR TITLE
fix: CI tag prefix - prevent invalid Docker tag format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/yacht
           tags: |
             type=ref,event=branch
-            type=sha,prefix={{branch}}-
+            type=sha,prefix={{branch}}-sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push


### PR DESCRIPTION
Fixes Docker build failure: invalid tag format "ghcr.io/yacht-sh/yacht:-17b9bbe" when branch name is empty (PR/merge builds).