### PR TITLE
Add Docker Hub push to Deploy to GH Packages workflow

### DIFF
--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -32,11 +32,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKHUB_PAT }}
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/yacht
+          images: |
+            ghcr.io/${{ github.repository_owner }}/yacht
+            docker.io/${{ secrets.DOCKERHUB_USER }}/yacht
           tags: |
             type=sha,prefix={{branch}}-sha-
             type=raw,value=latest

--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -47,7 +47,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/yacht
             docker.io/${{ secrets.DOCKERHUB_USER }}/yacht
           tags: |
-            type=sha,prefix={{branch}}-sha-
+            type=sha,prefix=sha-
             type=raw,value=latest
             type=raw,value=${{ github.sha }}
 


### PR DESCRIPTION
Uses DOCKERHUB_USER and DOCKHUB_PAT secrets to push the same multi-arch image to Docker Hub alongside GitHub Packages.