### PR TITLE
fix(gh-packages): make Docker Hub login non-blocking

### DIFF
--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -38,6 +38,7 @@ jobs:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKHUB_PAT }}
+        continue-on-error: true
 
       - name: Extract metadata
         id: meta


### PR DESCRIPTION
Adds continue-on-error: true to the Docker Hub login step so GHCR push still succeeds if Docker Hub credentials are missing.