### PR TITLE
fix(gh-packages): guard Docker Hub tags with secret presence

### DIFF
--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -33,6 +33,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
+        if: secrets.DOCKERHUB_USER != ''
         uses: docker/login-action@v3
         with:
           registry: docker.io
@@ -46,7 +47,7 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/yacht
-            docker.io/${{ secrets.DOCKERHUB_USER }}/yacht
+            ${{ secrets.DOCKERHUB_USER != '' && format('docker.io/{0}/yacht', secrets.DOCKERHUB_USER) }}
           tags: |
             type=sha,prefix=sha-
             type=raw,value=latest


### PR DESCRIPTION
Prevents invalid `docker.io//yacht:*` tags when `DOCKERHUB_USER` is absent by making Docker Hub login conditional and omitting Docker Hub images from metadata when the secret is missing.