### PR TITLE
fix(auth): make CSRF cookie protection configurable for HTTP deploys

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -51,7 +51,7 @@ class jwtSettings(BaseModel):
     authjwt_secret_key: str = generate_secret_key(db=SessionLocal())
     authjwt_token_location: list = ["headers", "cookies"]
     authjwt_cookie_secure: bool = settings.SECURE_COOKIES
-    authjwt_cookie_csrf_protect: bool = True
+    authjwt_cookie_csrf_protect: bool = settings.ENABLE_CSRF_PROTECTION
     authjwt_access_token_expires: int = int(settings.ACCESS_TOKEN_EXPIRES)
     authjwt_refresh_token_expires: int = int(settings.REFRESH_TOKEN_EXPIRES)
     authjwt_cookie_samesite: str = settings.SAME_SITE_COOKIES

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -39,6 +39,7 @@ class Settings(BaseSettings):
     ENABLE_SECURITY_HEADERS: bool = env_bool("ENABLE_SECURITY_HEADERS", True)
     ENABLE_HTTPS_REDIRECT: bool = env_bool("ENABLE_HTTPS_REDIRECT", False)
     EXPOSE_API_DOCS: bool = env_bool("EXPOSE_API_DOCS", False)
+    ENABLE_CSRF_PROTECTION: bool = env_bool("ENABLE_CSRF_PROTECTION", True)
     HSTS_SECONDS: int = int(os.environ.get("HSTS_SECONDS", 31536000))
     TRUSTED_HOSTS: list[str] = env_list("TRUSTED_HOSTS")
     AGENT_ENROLLMENT_TOKEN: str = os.environ.get("AGENT_ENROLLMENT_TOKEN", "")


### PR DESCRIPTION
Adds `ENABLE_CSRF_PROTECTION` so HTTP test deployments like docker1 can disable strict `__Host-` cookie CSRF requirements that currently block `/auth/me` and `/auth/refresh`.